### PR TITLE
fix: READMEのインストール手順をBOOTHリンクに置き換え

### DIFF
--- a/Packages/com.tsukumodo.avatar-omamori/README.md
+++ b/Packages/com.tsukumodo.avatar-omamori/README.md
@@ -16,16 +16,9 @@ VRChatアバターの設定ミスをビルド前に一括検出するUnity Edito
 - VRChat SDK - Avatars 3.5.0 以降
 - Modular Avatar（オプション — 未インストール時はMAチェックをスキップ）
 
-## インストール
+## ダウンロード
 
-### VPM (推奨)
-
-VCC (VRChat Creator Companion) に本リポジトリを追加し、パッケージをインストールしてください。
-
-### 手動
-
-1. `Packages/` フォルダに本リポジトリをクローンまたはコピー
-2. Unity がコンパイルし、`Tools > アバター改変おまもり` メニューが表示されることを確認
+[BOOTH](https://tsukumodo-lab.booth.pm/items/8132860) からダウンロードしてください。
 
 ## 使い方
 

--- a/README.md
+++ b/README.md
@@ -2,22 +2,9 @@
 
 VRChatアバターの設定ミスをビルド前に一括検出するUnity Editor拡張です。
 
-## インストール
+## ダウンロード
 
-### VCC から追加（推奨）
-
-1. 以下のボタンをクリックして VCC にリポジトリを追加：
-
-   [VCC に追加](vcc://vpm/addRepo?url=https://tsukumodo.github.io/omamori/index.json)
-
-2. VCC の「Manage Project」から「アバター改変おまもり」をインストール
-
-VPMリポジトリURL: `https://tsukumodo.github.io/omamori/index.json`
-
-### 手動インストール
-
-1. `Packages/` フォルダに本パッケージをクローンまたはコピー
-2. Unity がコンパイルし、`Tools > アバター改変おまもり` メニューが表示されることを確認
+[BOOTH](https://tsukumodo-lab.booth.pm/items/8132860) からダウンロードしてください。
 
 ## 動作要件
 


### PR DESCRIPTION
BOOTHでの販売を守るため、VPMリポジトリURLや手動インストール手順を削除し、
BOOTHページへのリンクに置き換え。