### PR TITLE
feat(v0.5.0-phase0): #8 Animator Layer Weight=0 自動修正の最小実装

### DIFF
--- a/Packages/com.tsukumodo.avatar-omamori/CHANGELOG.md
+++ b/Packages/com.tsukumodo.avatar-omamori/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+### 追加
+- 自動修正の基盤を追加（CheckResult に FixAction を持たせ、UI に「修正」ボタンを表示）
+- #8 Animator Layer Weight=0 の自動修正を実装（Weight=0 を 1 に変更、Undo 対応）
+
 ## [0.4.0] - 2026-04-11
 ### Added
 - [SDK] Animator Layer Weight チェック（FXレイヤーの Weight=0 を検出・警告）

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/AvatarOmamoriWindow.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/AvatarOmamoriWindow.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
@@ -151,6 +152,33 @@ namespace AvatarOmamori.Editor
                     {
                         EditorGUIUtility.PingObject(result.TargetObject);
                         Selection.activeObject = result.TargetObject;
+                    }
+                }
+
+                if (result.HasFix)
+                {
+                    var fixLabel = result.FixLabel ?? "修正";
+                    // デフォルト「修正」のときは「選択」ボタンと幅を揃え、カスタムラベル指定時のみ内容に合わせて広げる
+                    var fixWidth = result.FixLabel == null
+                        ? 40f
+                        : GUI.skin.button.CalcSize(new GUIContent(fixLabel)).x + 8f;
+                    if (GUILayout.Button(fixLabel, GUILayout.Width(fixWidth)))
+                    {
+                        var msg = result.FixConfirmMessage ?? "この問題を自動修正しますか？\nUndo（Ctrl+Z）で元に戻せます。";
+                        if (EditorUtility.DisplayDialog("おまもり — 自動修正", msg, "修正する", "キャンセル"))
+                        {
+                            try
+                            {
+                                result.FixAction();
+                                _results = CheckRunner.RunAll(_avatarRoot);
+                                CacheResultsByCategory();
+                                Repaint();
+                            }
+                            catch (Exception e)
+                            {
+                                EditorUtility.DisplayDialog("おまもり — エラー", $"修正中にエラーが発生しました。\n{e.Message}", "OK");
+                            }
+                        }
                     }
                 }
 

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/CheckResult.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/CheckResult.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace AvatarOmamori.Editor
@@ -17,7 +18,7 @@ namespace AvatarOmamori.Editor
 
     /// <summary>
     /// 個別のチェック結果を表すデータクラス。
-    /// 重要度、メッセージ、および問題の対象オブジェクトへの参照を保持する。
+    /// 重要度、メッセージ、問題の対象オブジェクトへの参照、および自動修正アクションを保持する。
     /// </summary>
     public sealed class CheckResult
     {
@@ -28,7 +29,19 @@ namespace AvatarOmamori.Editor
         public string Message { get; }
 
         /// <summary>問題が検出された Unity オブジェクト。Hierarchy での選択・ハイライトに使用される。</summary>
-        public Object TargetObject { get; }
+        public UnityEngine.Object TargetObject { get; }
+
+        /// <summary>自動修正を実行するアクション。null なら修正ボタンを表示しない。</summary>
+        public Action FixAction { get; }
+
+        /// <summary>修正ボタンの文言。null なら UI 側で "修正" を使う。</summary>
+        public string FixLabel { get; }
+
+        /// <summary>修正前の確認ダイアログ本文。null なら UI 側でデフォルト文言を使う。</summary>
+        public string FixConfirmMessage { get; }
+
+        /// <summary>自動修正が利用可能かどうか。</summary>
+        public bool HasFix => FixAction != null;
 
         /// <summary>
         /// <see cref="CheckResult"/> の新しいインスタンスを作成する。
@@ -36,11 +49,23 @@ namespace AvatarOmamori.Editor
         /// <param name="severity">結果の重要度。</param>
         /// <param name="message">ユーザーに表示するメッセージ。</param>
         /// <param name="targetObject">問題の対象オブジェクト（任意）。</param>
-        public CheckResult(Severity severity, string message, Object targetObject = null)
+        /// <param name="fixAction">自動修正アクション（任意）。null なら修正ボタン非表示。</param>
+        /// <param name="fixLabel">修正ボタンの文言（任意）。null なら "修正"。</param>
+        /// <param name="fixConfirmMessage">確認ダイアログ本文（任意）。null ならデフォルト文言。</param>
+        public CheckResult(
+            Severity severity,
+            string message,
+            UnityEngine.Object targetObject = null,
+            Action fixAction = null,
+            string fixLabel = null,
+            string fixConfirmMessage = null)
         {
             Severity = severity;
             Message = message;
             TargetObject = targetObject;
+            FixAction = fixAction;
+            FixLabel = fixLabel;
+            FixConfirmMessage = fixConfirmMessage;
         }
     }
 }

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/AnimatorLayerWeightCheck.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/AnimatorLayerWeightCheck.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using UnityEditor;
 using UnityEditor.Animations;
 using UnityEngine;
 using VRC.SDK3.Avatars.Components;
@@ -52,13 +53,34 @@ namespace AvatarOmamori.Editor.Checks
             {
                 if (layers[i].defaultWeight == 0f)
                 {
+                    // クロージャでキャプチャするため、ループ変数をローカルコピーに取る
+                    var capturedController = animatorController;
+                    var capturedIndex = i;
+                    var capturedName = layers[i].name;
+
                     yield return new CheckResult(
                         Severity.Warning,
                         $"[SDK] FX レイヤー \"{layers[i].name}\" (index {i}) の Weight が 0 です。このレイヤーのアニメーションは反映されません。Weight を 1 に変更してください。",
-                        descriptor
+                        descriptor,
+                        fixAction: () => SetLayerWeightToOne(capturedController, capturedIndex),
+                        fixConfirmMessage: $"FXレイヤー「{capturedName}」のWeightを 0 → 1 に変更します。\nUndo（Ctrl+Z）で元に戻せます。"
                     );
                 }
             }
+        }
+
+        /// <summary>
+        /// 指定レイヤーの defaultWeight を 1 に設定する。
+        /// AnimatorController.layers の getter はコピーを返すため、ローカル変数で変更してからセットし直す。
+        /// </summary>
+        private static void SetLayerWeightToOne(AnimatorController controller, int layerIndex)
+        {
+            Undo.RecordObject(controller, "Fix Animator Layer Weight");
+            var layers = controller.layers;
+            layers[layerIndex].defaultWeight = 1f;
+            controller.layers = layers;
+            EditorUtility.SetDirty(controller);
+            AssetDatabase.SaveAssets();
         }
 
         /// <summary>


### PR DESCRIPTION
## 概要

v0.5.0 の Phase 0 として「自動修正の共通基盤」を最小実装。
#8 Animator Layer Weight=0 の自動修正を最初の実証ケースとして実装した。

## 実装内容

### 自動修正基盤（CheckResult の拡張）

`CheckResult` に以下の任意フィールドを追加。既存呼び出しを壊さないためコンストラクタ末尾に追加引数として、デフォルト値 null で受ける:

- `FixAction: System.Action` — null なら修正ボタン非表示
- `FixLabel: string` — null なら UI 側で「修正」を使用
- `FixConfirmMessage: string` — null ならデフォルト確認文言
- `HasFix: bool` — 計算プロパティ（FixAction != null）

### #8 Animator Layer Weight=0 の自動修正

`AnimatorLayerWeightCheck` の Warning 結果に FixAction を実装:

- `SetLayerWeightToOne(controller, layerIndex)` ヘルパーで Weight を 1 に変更
- `Undo.RecordObject` → ローカル変数に layers を取得 → 該当 index の defaultWeight を 1f に → `controller.layers = layers;` で書き戻し → `EditorUtility.SetDirty` + `AssetDatabase.SaveAssets`
- `AnimatorController.layers` の getter はコピーを返す挙動を前提に、ローカル変数で書き換えてからセットし直すパターン

### EditorWindow の UI

`DrawSeverityGroup` に「修正」ボタンを追加:

- `result.HasFix` が true のときだけ表示
- ボタン押下 → `EditorUtility.DisplayDialog` で確認
- OK → `result.FixAction()` を try/catch で実行 → 例外時はエラーダイアログ
- 成功時は `CheckRunner.RunAll` を呼び直して結果を更新、Repaint
- 「選択」ボタンと幅を揃え（40px 固定）、FixLabel カスタム指定時のみ内容に合わせて動的計算

## 動作確認結果（ローカル）

- [x] プロジェクトがコンパイル通る
- [x] FX レイヤー Weight=0 を仕込んだアバターでチェック実行 → Warning カードに「修正」ボタンが表示
- [x] ボタン押下で確認ダイアログ表示
- [x] OK 押下 → Animator ウィンドウで Weight が 0 → 1 に変わる
- [x] Ctrl+Z で Weight が 0 に戻る（Undo 動作確認）
- [x] 修正後、結果リストから該当 Warning が消える（自動再チェック）

## 既存チェックへの影響

- CheckResult のコンストラクタ追加引数はすべて任意（デフォルト null）のため、既存の他チェックの呼び出しは無変更で動作

## Phase 1 への足場

このスパイクで以下の足場ができたため、Phase 1 で予定している自動修正（#1 Descriptor 重複 / #4 Missing Script など）も同パターンで追加可能:

- `CheckResult` に FixAction を渡すだけで UI に修正ボタンが出る
- 確認ダイアログ・例外ハンドリング・自動再チェックは UI 側で共通処理されるので、各チェックは「修正処理本体」を実装するだけで済む

🤖 Generated with [Claude Code](https://claude.com/claude-code)