### PR TITLE
feat(v0.5.0-phase1): #4 Missing Script + #1 Descriptor 重複の自動修正

### DIFF
--- a/Packages/com.tsukumodo.avatar-omamori/CHANGELOG.md
+++ b/Packages/com.tsukumodo.avatar-omamori/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## [Unreleased]
 ### 追加
+- アバタールート指定時にチェックを自動実行するように変更（従来は「チェック実行」ボタン押下が必須。ボタンは引き続き手動再チェック用に利用可能）
 - 自動修正の基盤を追加（CheckResult に FixAction を持たせ、UI に「修正」ボタンを表示）
 - #8 Animator Layer Weight=0 の自動修正を実装（Weight=0 を 1 に変更、Undo 対応）
+- #4 Missing Script の自動修正を実装（GameObject 上の Missing Script を一括削除。Unity の API 仕様で Undo 不可だが、Missing Script は元々参照が壊れているため実質的なデータ損失はなく、事前確認でその旨を明示）
+- #1 VRC Avatar Descriptor 重複の自動修正を実装（複数の Descriptor から「どれを残すか」を選ぶドロップダウンで解消。本体が推奨、選んだもの以外は一括削除で Undo 対応）
+- 共通基盤に SkipConfirm フラグを追加（修正処理が独自の UI（ダイアログ・ドロップダウン等）を出す場合に、共通基盤側の事前確認と自動再チェックをスキップする）
 
 ## [0.4.0] - 2026-04-11
 ### Added

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/AvatarOmamoriWindow.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/AvatarOmamoriWindow.cs
@@ -32,14 +32,43 @@ namespace AvatarOmamori.Editor
             GetWindow<AvatarOmamoriWindow>("アバター改変おまもり");
         }
 
+        /// <summary>
+        /// 現在のアバタールートに対してチェックを再実行し、UI を更新する。
+        /// FixAction が非同期的な処理（選択ドロップダウン等）を含み、完了のタイミングを
+        /// 共通基盤側で知れない場合、FixAction 側から明示的に呼び出して UI を最新状態に戻す。
+        /// </summary>
+        public void RefreshResults()
+        {
+            if (_avatarRoot == null) return;
+            _results = CheckRunner.RunAll(_avatarRoot);
+            CacheResultsByCategory();
+            Repaint();
+        }
+
         private void OnGUI()
         {
             EditorGUILayout.Space(4);
             EditorGUILayout.LabelField("アバター改変おまもり", EditorStyles.boldLabel);
             EditorGUILayout.Space(2);
 
-            _avatarRoot = (GameObject)EditorGUILayout.ObjectField(
+            var newAvatarRoot = (GameObject)EditorGUILayout.ObjectField(
                 "アバタールート", _avatarRoot, typeof(GameObject), true);
+            if (newAvatarRoot != _avatarRoot)
+            {
+                _avatarRoot = newAvatarRoot;
+                // アバターを指定した瞬間に自動チェックを走らせる。
+                // オンボーディング時のボタン押し忘れを防ぎ、ツールの価値をすぐに体験してもらうため。
+                if (_avatarRoot != null)
+                {
+                    _results = CheckRunner.RunAll(_avatarRoot);
+                    CacheResultsByCategory();
+                }
+                else
+                {
+                    // アバター参照がクリアされたら結果も消す（古い結果が残ると誤解の元）
+                    _results = null;
+                }
+            }
 
             EditorGUILayout.Space(4);
 
@@ -164,20 +193,22 @@ namespace AvatarOmamori.Editor
                         : GUI.skin.button.CalcSize(new GUIContent(fixLabel)).x + 8f;
                     if (GUILayout.Button(fixLabel, GUILayout.Width(fixWidth)))
                     {
-                        var msg = result.FixConfirmMessage ?? "この問題を自動修正しますか？\nUndo（Ctrl+Z）で元に戻せます。";
-                        if (EditorUtility.DisplayDialog("おまもり — 自動修正", msg, "修正する", "キャンセル"))
+                        var capturedResult = result;
+                        if (capturedResult.SkipConfirm)
                         {
-                            try
-                            {
-                                result.FixAction();
-                                _results = CheckRunner.RunAll(_avatarRoot);
-                                CacheResultsByCategory();
-                                Repaint();
-                            }
-                            catch (Exception e)
-                            {
-                                EditorUtility.DisplayDialog("おまもり — エラー", $"修正中にエラーが発生しました。\n{e.Message}", "OK");
-                            }
+                            // FixAction 側で独自ウィンドウを出す項目（例: Descriptor 重複の選択ウィンドウ）。
+                            // 事前確認は出さず、再チェックも FixAction 側が完了時に RefreshResults() を呼ぶ責任を持つ。
+                            ExecuteFix(capturedResult, refreshAfter: false);
+                        }
+                        else
+                        {
+                            var msg = capturedResult.FixConfirmMessage ?? "この問題を自動修正しますか？\nUndo（Ctrl+Z）で元に戻せます。";
+                            OmamoriConfirmWindow.Show(
+                                title: "おまもり — 自動修正",
+                                message: msg,
+                                okLabel: "修正する",
+                                cancelLabel: "キャンセル",
+                                onOk: () => ExecuteFix(capturedResult, refreshAfter: true));
                         }
                     }
                 }
@@ -187,6 +218,37 @@ namespace AvatarOmamori.Editor
                 EditorGUILayout.Space(2);
             }
             EditorGUI.indentLevel--;
+        }
+
+        /// <summary>
+        /// FixAction を安全に実行する。
+        /// 同期的な修正は <paramref name="refreshAfter"/>=true で直後に再チェックする。
+        /// 非同期的な修正（内部で独自 UI を開くもの）は <paramref name="refreshAfter"/>=false で呼び、
+        /// FixAction 側が完了時に <see cref="RefreshResults"/> を呼ぶ責任を持つ。
+        /// </summary>
+        private void ExecuteFix(CheckResult result, bool refreshAfter)
+        {
+            try
+            {
+                result.FixAction();
+                if (refreshAfter)
+                {
+                    RefreshResults();
+                }
+            }
+            catch (ExitGUIException)
+            {
+                // Unity の GUI システムが「現フレームの GUI 処理を中断する」ために投げる正常動作の例外
+                // （PopupWindow.Show 等が投げる）。アプリレベルのエラーではないので Unity に委ねる。
+                throw;
+            }
+            catch (Exception e)
+            {
+                EditorUtility.DisplayDialog(
+                    "おまもり — エラー",
+                    $"修正中にエラーが発生しました。\n{e.Message}",
+                    "OK");
+            }
         }
 
         private static GUIContent GetSeverityIcon(Severity severity)

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/CheckResult.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/CheckResult.cs
@@ -40,6 +40,14 @@ namespace AvatarOmamori.Editor
         /// <summary>修正前の確認ダイアログ本文。null なら UI 側でデフォルト文言を使う。</summary>
         public string FixConfirmMessage { get; }
 
+        /// <summary>
+        /// true の場合、共通 UI の事前確認ダイアログと修正後の自動再チェックをスキップする。
+        /// FixAction 内で独自のダイアログ・ドロップダウン等の非同期 UI を出す修正項目で、
+        /// 二重ダイアログの回避と、UI 完了前の再チェック暴発の抑止を兼ねる。
+        /// この場合、FixAction 側は完了時に <see cref="AvatarOmamoriWindow.RefreshResults"/> を呼ぶ責任を持つ。
+        /// </summary>
+        public bool SkipConfirm { get; }
+
         /// <summary>自動修正が利用可能かどうか。</summary>
         public bool HasFix => FixAction != null;
 
@@ -52,13 +60,15 @@ namespace AvatarOmamori.Editor
         /// <param name="fixAction">自動修正アクション（任意）。null なら修正ボタン非表示。</param>
         /// <param name="fixLabel">修正ボタンの文言（任意）。null なら "修正"。</param>
         /// <param name="fixConfirmMessage">確認ダイアログ本文（任意）。null ならデフォルト文言。</param>
+        /// <param name="skipConfirm">true にすると事前確認ダイアログを省略する（FixAction 側で独自にダイアログを出す場合用）。</param>
         public CheckResult(
             Severity severity,
             string message,
             UnityEngine.Object targetObject = null,
             Action fixAction = null,
             string fixLabel = null,
-            string fixConfirmMessage = null)
+            string fixConfirmMessage = null,
+            bool skipConfirm = false)
         {
             Severity = severity;
             Message = message;
@@ -66,6 +76,7 @@ namespace AvatarOmamori.Editor
             FixAction = fixAction;
             FixLabel = fixLabel;
             FixConfirmMessage = fixConfirmMessage;
+            SkipConfirm = skipConfirm;
         }
     }
 }

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/DescriptorDuplicateCheck.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/DescriptorDuplicateCheck.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using AvatarOmamori.Editor.Util;
+using UnityEditor;
 using UnityEngine;
 using VRC.SDK3.Avatars.Components;
 
@@ -25,13 +26,26 @@ namespace AvatarOmamori.Editor.Checks
             if (descriptors.Length <= 1)
                 yield break;
 
+            // クロージャで捕捉するためローカルに退避
+            var capturedRoot = avatarRoot;
+            var capturedDescriptors = descriptors;
+
+            string summaryMessage =
+                $"VRC Avatar Descriptor が {descriptors.Length} 個見つかりました。" +
+                "複数あるとアバターのビルド・アップロードに失敗します。" +
+                "「修正」ボタンで「どれを残すか」を選ぶウィンドウが開きます（選んだもの以外を自動削除、Undo 対応）。";
+
             yield return new CheckResult(
                 Severity.Error,
-                $"VRC Avatar Descriptor が {descriptors.Length} 個見つかりました。複数あるとアバターのビルド・アップロードに失敗します。アバタールートに1つだけ配置してください。",
-                avatarRoot
+                summaryMessage,
+                avatarRoot,
+                fixAction: () => ShowResolveWindow(capturedRoot, capturedDescriptors),
+                fixLabel: null,                    // 共通「修正」で統一
+                fixConfirmMessage: null,           // SkipConfirm=true のとき未使用
+                skipConfirm: true                  // 独自の選択ウィンドウを出すので事前確認・自動再チェックともスキップ
             );
 
-            // 各重複箇所も報告
+            // 各重複箇所も検出行として報告（FixAction はサマリー側に集約済み）
             for (int i = 1; i < descriptors.Length; i++)
             {
                 yield return new CheckResult(
@@ -39,6 +53,58 @@ namespace AvatarOmamori.Editor.Checks
                     $"重複した VRC Avatar Descriptor: {HierarchyPathUtil.GetHierarchyPath(descriptors[i].gameObject)}",
                     descriptors[i]
                 );
+            }
+        }
+
+        /// <summary>
+        /// 「どの Descriptor を残すか」を選ぶウィンドウを中央表示する。
+        /// 選択されたら、選ばれた Descriptor 以外を一括削除してからおまもりウィンドウを再チェックする。
+        /// </summary>
+        private static void ShowResolveWindow(
+            GameObject avatarRoot,
+            VRCAvatarDescriptor[] descriptors)
+        {
+            DescriptorChoiceWindow.Show(avatarRoot, descriptors, keep =>
+            {
+                RemoveAllExcept(descriptors, keep);
+                RefreshOmamoriWindow();
+            });
+        }
+
+        /// <summary>
+        /// <paramref name="keep"/> 以外の Descriptor を一括削除する。
+        /// 複数削除を1つの Undo 単位にまとめ、Ctrl+Z で一度に戻せるようにする。
+        /// GameObject ごと削除すると他のコンポーネントや子を巻き込むので、コンポーネントだけを削除する。
+        /// </summary>
+        private static void RemoveAllExcept(
+            VRCAvatarDescriptor[] all,
+            VRCAvatarDescriptor keep)
+        {
+            Undo.IncrementCurrentGroup();
+            Undo.SetCurrentGroupName("Resolve Duplicate VRC Avatar Descriptors");
+            int group = Undo.GetCurrentGroup();
+
+            foreach (var d in all)
+            {
+                if (d != null && d != keep)
+                {
+                    Undo.DestroyObjectImmediate(d);
+                }
+            }
+
+            Undo.CollapseUndoOperations(group);
+        }
+
+        /// <summary>
+        /// 既存のおまもりウィンドウに再チェックを指示する。
+        /// FixAction が非同期（選択ウィンドウ閉じた後に処理）なので、共通基盤の自動再チェックに乗れない。
+        /// </summary>
+        private static void RefreshOmamoriWindow()
+        {
+            var windows = Resources.FindObjectsOfTypeAll<AvatarOmamoriWindow>();
+            foreach (var w in windows)
+            {
+                w.RefreshResults();
             }
         }
     }

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/DescriptorDuplicateCheck.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/DescriptorDuplicateCheck.cs
@@ -26,10 +26,6 @@ namespace AvatarOmamori.Editor.Checks
             if (descriptors.Length <= 1)
                 yield break;
 
-            // クロージャで捕捉するためローカルに退避
-            var capturedRoot = avatarRoot;
-            var capturedDescriptors = descriptors;
-
             string summaryMessage =
                 $"VRC Avatar Descriptor が {descriptors.Length} 個見つかりました。" +
                 "複数あるとアバターのビルド・アップロードに失敗します。" +
@@ -39,7 +35,8 @@ namespace AvatarOmamori.Editor.Checks
                 Severity.Error,
                 summaryMessage,
                 avatarRoot,
-                fixAction: () => ShowResolveWindow(capturedRoot, capturedDescriptors),
+                // avatarRoot / descriptors はメソッド引数とローカル変数で再代入されないため、ラムダで直接捕捉して問題ない
+                fixAction: () => ShowResolveWindow(avatarRoot, descriptors),
                 fixLabel: null,                    // 共通「修正」で統一
                 fixConfirmMessage: null,           // SkipConfirm=true のとき未使用
                 skipConfirm: true                  // 独自の選択ウィンドウを出すので事前確認・自動再チェックともスキップ

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/MissingScriptCheck.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/MissingScriptCheck.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using AvatarOmamori.Editor.Util;
 using UnityEditor;
+using UnityEditor.SceneManagement;
 using UnityEngine;
 
 namespace AvatarOmamori.Editor.Checks
@@ -31,12 +32,49 @@ namespace AvatarOmamori.Editor.Checks
                 if (missingCount > 0)
                 {
                     var path = HierarchyPathUtil.GetHierarchyPath(go);
+
+                    // ループ変数を直接ラムダに渡すとイテレーション共有で誤ったオブジェクトを参照する恐れがあるのでローカルにキャプチャする
+                    var capturedGo = go;
+                    var capturedCount = missingCount;
+
                     yield return new CheckResult(
                         Severity.Error,
-                        $"[Unity] {path} に Missing Script が {missingCount} 個あります。不要なMissing Scriptは右クリック → Remove Componentで削除してください。",
-                        go
+                        $"[Unity] {path} に Missing Script が {missingCount} 個あります。「修正」ボタンで一括削除できます（Inspector の右クリック → Remove Component からも削除可能）。",
+                        go,
+                        fixAction: () => RemoveMissingScripts(capturedGo),
+                        fixConfirmMessage:
+                            $"「{capturedGo.name}」から Missing Script を {capturedCount} 個削除します。\n" +
+                            "※この操作は Undo（Ctrl+Z）で元に戻せません。\n" +
+                            "Missing Script はすでにスクリプト参照が壊れているコンポーネントなので、削除しても実質的なデータ損失はありません。"
                     );
                 }
+            }
+        }
+
+        /// <summary>
+        /// 指定 GameObject から Missing Script を全て削除する。
+        /// </summary>
+        /// <remarks>
+        /// Unity の仕様上、この操作は Undo（Ctrl+Z）で巻き戻せない：
+        /// <list type="bullet">
+        ///   <item><see cref="GameObjectUtility.RemoveMonoBehavioursWithMissingScript"/> は Undo 非対応。</item>
+        ///   <item><see cref="SerializedObject"/> 経由で <c>m_Component</c> を直接編集する方式は、
+        ///   Unity 側が保護データとして弾く（"It is not allowed to modify the data property"）。</item>
+        /// </list>
+        /// そのため、事前確認ダイアログで「Undo で戻せない」旨をユーザーに明示する。
+        /// Missing Script は既に参照が壊れているコンポーネントなので、削除で失う情報は実質ない。
+        /// </remarks>
+        private static void RemoveMissingScripts(GameObject target)
+        {
+            GameObjectUtility.RemoveMonoBehavioursWithMissingScript(target);
+            EditorUtility.SetDirty(target);
+
+            // シーン上の GameObject の変更は SceneDirty を立てないと保存時に反映されないため明示的にマークする。
+            // Prefab アセット上のオブジェクトは scene.IsValid() が false になるので SetDirty のみで十分。
+            var scene = target.scene;
+            if (scene.IsValid())
+            {
+                EditorSceneManager.MarkSceneDirty(scene);
             }
         }
     }

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/DescriptorChoiceWindow.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/DescriptorChoiceWindow.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Linq;
+using AvatarOmamori.Editor.Util;
+using UnityEditor;
+using UnityEngine;
+using VRC.SDK3.Avatars.Components;
+
+namespace AvatarOmamori.Editor
+{
+    /// <summary>
+    /// 「どの VRC Avatar Descriptor を残すか」を選ばせる確認ウィンドウ。
+    /// <see cref="EditorWindow"/> ベースで画面中央に浮遊表示し、
+    /// 確認用の <see cref="OmamoriConfirmWindow"/> とスタイルを統一する。
+    /// </summary>
+    internal sealed class DescriptorChoiceWindow : EditorWindow
+    {
+        private const string HelpMessage =
+            "複数の VRC Avatar Descriptor が見つかりました。\n" +
+            "残すものを選んでください。選んだもの以外は削除されます（Undo で戻せます）。";
+
+        private GameObject _avatarRoot;
+        private VRCAvatarDescriptor[] _descriptors;
+        private VRCAvatarDescriptor[] _ordered;
+        private Action<VRCAvatarDescriptor> _onChosen;
+        private Vector2 _scroll;
+
+        public static void Show(
+            GameObject avatarRoot,
+            VRCAvatarDescriptor[] descriptors,
+            Action<VRCAvatarDescriptor> onChosen)
+        {
+            var window = CreateInstance<DescriptorChoiceWindow>();
+            window.titleContent = new GUIContent("おまもり — 残す Descriptor を選んでください");
+            window._avatarRoot = avatarRoot;
+            window._descriptors = descriptors;
+            window._ordered = descriptors
+                .OrderBy(d => d.gameObject == avatarRoot ? 0 : 1)
+                .ThenBy(d => HierarchyPathUtil.GetHierarchyPath(d.gameObject))
+                .ToArray();
+            window._onChosen = onChosen;
+
+            const float width = 520f;
+            float height = CalcHeight(window._ordered.Length);
+            window.minSize = new Vector2(width, height);
+            window.maxSize = new Vector2(width, height);
+            window.position = OmamoriPopupStyles.CenterOfMainWindow(width, height);
+
+            window.ShowUtility();
+        }
+
+        private static float CalcHeight(int itemCount)
+        {
+            const float perItem = 30f;      // 候補ボタン1行
+            const float footerHeight = 40f; // キャンセル + 余白
+            const float paddingHeight = 24f;
+            const float maxHeight = 600f;
+
+            float infoBoxHeight = OmamoriPopupStyles.CalcInfoBoxHeight(HelpMessage);
+            float height = paddingHeight + infoBoxHeight + itemCount * perItem + footerHeight;
+            return Mathf.Min(height, maxHeight);
+        }
+
+        private void OnGUI()
+        {
+            EditorGUILayout.Space(8);
+            OmamoriPopupStyles.DrawInfoBox(HelpMessage);
+            EditorGUILayout.Space(6);
+
+            _scroll = EditorGUILayout.BeginScrollView(_scroll);
+            foreach (var descriptor in _ordered)
+            {
+                if (descriptor == null) continue;
+                var go = descriptor.gameObject;
+                bool isRoot = go == _avatarRoot;
+                string label = isRoot
+                    ? $"本体「{go.name}」を残す（推奨）"
+                    : $"子「{HierarchyPathUtil.GetHierarchyPath(go)}」を残す";
+
+                if (GUILayout.Button(label, GUILayout.Height(26)))
+                {
+                    var keep = descriptor;
+                    var callback = _onChosen;
+                    Close();
+                    callback?.Invoke(keep);
+                    return;
+                }
+            }
+            EditorGUILayout.EndScrollView();
+
+            EditorGUILayout.Space(4);
+            EditorGUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+            if (GUILayout.Button("キャンセル", GUILayout.Height(24), GUILayout.Width(110)))
+            {
+                Close();
+            }
+            GUILayout.FlexibleSpace();
+            EditorGUILayout.EndHorizontal();
+            EditorGUILayout.Space(8);
+        }
+    }
+}

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/DescriptorChoiceWindow.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/DescriptorChoiceWindow.cs
@@ -19,7 +19,6 @@ namespace AvatarOmamori.Editor
             "残すものを選んでください。選んだもの以外は削除されます（Undo で戻せます）。";
 
         private GameObject _avatarRoot;
-        private VRCAvatarDescriptor[] _descriptors;
         private VRCAvatarDescriptor[] _ordered;
         private Action<VRCAvatarDescriptor> _onChosen;
         private Vector2 _scroll;
@@ -32,7 +31,6 @@ namespace AvatarOmamori.Editor
             var window = CreateInstance<DescriptorChoiceWindow>();
             window.titleContent = new GUIContent("おまもり — 残す Descriptor を選んでください");
             window._avatarRoot = avatarRoot;
-            window._descriptors = descriptors;
             window._ordered = descriptors
                 .OrderBy(d => d.gameObject == avatarRoot ? 0 : 1)
                 .ThenBy(d => HierarchyPathUtil.GetHierarchyPath(d.gameObject))

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/DescriptorChoiceWindow.cs.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/DescriptorChoiceWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c2b8dba960b1cba49a4a6f19172904d2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/OmamoriConfirmWindow.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/OmamoriConfirmWindow.cs
@@ -1,0 +1,76 @@
+using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace AvatarOmamori.Editor
+{
+    /// <summary>
+    /// おまもり用の共通「確認ウィンドウ」。
+    /// <see cref="EditorWindow"/> ベースで画面中央に浮遊表示し、タイトルバー付きの独立ウィンドウとして見せる。
+    /// 選択用の <see cref="DescriptorChoiceWindow"/> とスタイルを統一する。
+    /// </summary>
+    internal sealed class OmamoriConfirmWindow : EditorWindow
+    {
+        private string _message;
+        private string _okLabel;
+        private string _cancelLabel;
+        private Action _onOk;
+
+        public static void Show(
+            string title,
+            string message,
+            string okLabel,
+            string cancelLabel,
+            Action onOk)
+        {
+            var window = CreateInstance<OmamoriConfirmWindow>();
+            window.titleContent = new GUIContent(title);
+            window._message = message;
+            window._okLabel = okLabel;
+            window._cancelLabel = cancelLabel;
+            window._onOk = onOk;
+
+            const float width = 480f;
+            float height = CalcHeight(message);
+            window.minSize = new Vector2(width, height);
+            window.maxSize = new Vector2(width, height);
+            window.position = OmamoriPopupStyles.CenterOfMainWindow(width, height);
+
+            // ShowUtility: 常に手前に浮く浮遊ウィンドウ（タイトルバー付き、ドッキング不可）
+            // EditorUtility.DisplayDialog に近い見た目で、他のウィンドウ操作もブロックしない
+            window.ShowUtility();
+        }
+
+        private static float CalcHeight(string message)
+        {
+            float infoBoxHeight = OmamoriPopupStyles.CalcInfoBoxHeight(message);
+            // 上下余白 + 情報ボックス + ボタン列 + 余白
+            return 16f + infoBoxHeight + 12f + 30f + 16f;
+        }
+
+        private void OnGUI()
+        {
+            EditorGUILayout.Space(8);
+            OmamoriPopupStyles.DrawInfoBox(_message);
+            EditorGUILayout.Space(8);
+
+            EditorGUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+            if (GUILayout.Button(_cancelLabel, GUILayout.Height(26), GUILayout.Width(110)))
+            {
+                Close();
+            }
+            GUILayout.Space(8);
+            if (GUILayout.Button(_okLabel, GUILayout.Height(26), GUILayout.Width(110)))
+            {
+                // 先にウィンドウを閉じてから FixAction を実行する（実行中にウィンドウが残らないように）
+                var onOk = _onOk;
+                Close();
+                onOk?.Invoke();
+            }
+            GUILayout.FlexibleSpace();
+            EditorGUILayout.EndHorizontal();
+            EditorGUILayout.Space(8);
+        }
+    }
+}

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/OmamoriConfirmWindow.cs.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/OmamoriConfirmWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2bbf8b7618f129f418cd8b4516008e42
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/OmamoriPopupStyles.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/OmamoriPopupStyles.cs
@@ -1,0 +1,83 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace AvatarOmamori.Editor
+{
+    /// <summary>
+    /// おまもりのポップアップで共通利用する GUIStyle と描画ヘルパー。
+    /// <see cref="EditorStyles.helpBox"/> のデフォルトフォントサイズは小さすぎて読みにくいため、
+    /// 12pt 相当に拡大したスタイルを本文表示に使う。
+    /// </summary>
+    internal static class OmamoriPopupStyles
+    {
+        private const float LineHeight = 18f;
+        private const float BoxVerticalPadding = 16f;
+
+        private static GUIStyle _infoBoxStyle;
+
+        /// <summary>本文用の拡大 HelpBox スタイル（fontSize 12 / 折り返しあり）。</summary>
+        public static GUIStyle InfoBox
+        {
+            get
+            {
+                // GUIStyle は OnGUI 内でしか初期化できないため遅延生成する
+                if (_infoBoxStyle == null)
+                {
+                    _infoBoxStyle = new GUIStyle(EditorStyles.helpBox)
+                    {
+                        fontSize = 12,
+                        wordWrap = true,
+                        alignment = TextAnchor.MiddleLeft,
+                        padding = new RectOffset(10, 10, 8, 8),
+                    };
+                }
+                return _infoBoxStyle;
+            }
+        }
+
+        /// <summary>
+        /// HelpBox 相当の見た目（情報アイコン + 枠）で、拡大フォントの説明文を描画する。
+        /// </summary>
+        public static void DrawInfoBox(string message)
+        {
+            var icon = EditorGUIUtility.IconContent("console.infoicon");
+            var content = new GUIContent(" " + message, icon.image);
+            GUILayout.Label(content, InfoBox);
+        }
+
+        /// <summary>
+        /// <see cref="DrawInfoBox"/> で描画した場合の想定高さ（概算）。
+        /// 明示的な改行数に応じて計算する（折り返しは考慮しないが、ウィンドウ幅が十分広ければ問題ない）。
+        /// </summary>
+        public static float CalcInfoBoxHeight(string message)
+        {
+            int lineCount = Mathf.Max(1, CountLines(message));
+            return BoxVerticalPadding + lineCount * LineHeight;
+        }
+
+        /// <summary>
+        /// Unity メインエディタウィンドウの中央に指定サイズの Rect を配置する。
+        /// 確認・選択ウィンドウの <see cref="EditorWindow.position"/> 計算で使う。
+        /// </summary>
+        public static Rect CenterOfMainWindow(float width, float height)
+        {
+            var main = EditorGUIUtility.GetMainWindowPosition();
+            return new Rect(
+                main.x + (main.width - width) / 2f,
+                main.y + (main.height - height) / 2f,
+                width,
+                height);
+        }
+
+        private static int CountLines(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return 1;
+            int n = 1;
+            foreach (var c in text)
+            {
+                if (c == '\n') n++;
+            }
+            return n;
+        }
+    }
+}

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/OmamoriPopupStyles.cs.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/OmamoriPopupStyles.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7fdc791494b43614b93740429d8ab63b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- **#4 Missing Script** の自動修正を実装（Unity 標準 API で GameObject 上の Missing Script を一括削除。Unity の API 仕様で Undo 不可だが、Missing Script はすでに参照が壊れているため実質的なデータ損失はなく、事前確認ダイアログでその旨を明示）
- **#1 VRC Avatar Descriptor 重複** の自動修正を実装（選択ウィンドウから「どれを残すか」選んで解消。2個〜N個を共通フローで処理、選んだもの以外を一括削除して Ctrl+Z 一度で復元可能。DEC-046 の選択ダイアログ方式を EditorWindow ベースで実装）
- **共通基盤**: `CheckResult.SkipConfirm` 追加、`AvatarOmamoriWindow.RefreshResults` 公開、`ExitGUIException` 再スローで独自 UI を出す修正も安全に扱えるように
- **UI 統一**: 事前確認・選択ウィンドウともに `EditorWindow` ベースの浮遊ウィンドウに統一（画面中央・タイトルバー付き）。`OmamoriPopupStyles` で本文スタイル（12pt InfoBox）と中央配置ロジックを共通化
- **アバタールート指定時に自動チェック**: ObjectField の変更を検知して即座にチェック実行（オンボーディング改善。「チェック実行」ボタンは手動再チェック用に保持）

## 実装ファイル
- 追加: `Editor/OmamoriConfirmWindow.cs`, `Editor/DescriptorChoiceWindow.cs`, `Editor/OmamoriPopupStyles.cs`
- 変更: `Editor/CheckResult.cs`, `Editor/AvatarOmamoriWindow.cs`, `Editor/Checks/MissingScriptCheck.cs`, `Editor/Checks/DescriptorDuplicateCheck.cs`, `CHANGELOG.md`

## Test plan
- [x] #4 Missing Script: 検出 → 事前確認（Undo 不可の警告表示）→ 「修正する」で削除 → 自動再チェックで検出行が消える
- [x] #1 Descriptor 重複（本体+子=2個）: 選択ウィンドウが中央表示 → 本体/子のいずれかを選ぶ → 選んだもの以外が削除 → Ctrl+Z で復元
- [x] #1 Descriptor 重複（3個以上）: 候補ボタンが全数並ぶ → いずれかを選ぶ → 選んだもの以外が一括削除 → Ctrl+Z 一度で全復元
- [x] #1 Descriptor 重複: 「キャンセル」で何も起きない
- [x] #8 Animator Weight=0（リグレッション確認）: 新しい確認ウィンドウで事前確認が表示されて動作する
- [x] アバタールート自動実行: アバター指定 → 即座に結果表示 / クリア → 結果が消える
- [x] UI 統一: すべてのポップアップが画面中央・タイトルバー付き・同じ本文スタイル

## 関連
- **DEC-046**: #1 Descriptor 重複は選択ダイアログ方式を採用（実装は EditorWindow ベース・N個共通対応に拡張）
- **Phase 0 (PR #15)**: 共通基盤と #8 Animator Layer Weight=0 を実装済み
- **Phase 1 (本PR)**: 残り2項目（#4, #1）を締め、v0.5.0 リリース準備完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)