### PR TITLE
v0.6.0 W1: 見える価値化（Before/After UI + 修正履歴）

### DIFF
--- a/Packages/com.tsukumodo.avatar-omamori/CHANGELOG.md
+++ b/Packages/com.tsukumodo.avatar-omamori/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### 追加
 - 自動修正の Before/After 表示用フィールドを `CheckResult` に追加（`ValueLabel` / `BeforeValue` / `AfterValue`）。Animator Layer Weight / Missing Script / VRC Avatar Descriptor 重複の3項目で、修正前後の値（予告）を保持
 - 結果カードに自動修正の Before/After（予告）を1行で表示（例: `FX Layer / Weight: 0 → 1`）。「修正」ボタンを押すと値がどう変わるかを事前に予告し、「直す力」を可視化
+- セッション内の自動修正履歴を「修正履歴」Foldout で表示。各修正の直前/直後の実値（予告値ではなく実測）と修正対象を時刻順に保持（上限100件、新しい順表示、Ping ボタン・クリアボタン付き、EditorWindow 終了で消える）
 
 ## [0.5.0] - 2026-04-28
 ### 追加

--- a/Packages/com.tsukumodo.avatar-omamori/CHANGELOG.md
+++ b/Packages/com.tsukumodo.avatar-omamori/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+### 追加
+- 自動修正の Before/After 表示用フィールドを `CheckResult` に追加（`ValueLabel` / `BeforeValue` / `AfterValue`）。Animator Layer Weight / Missing Script / VRC Avatar Descriptor 重複の3項目で、修正前後の値（予告）を保持
+- 結果カードに自動修正の Before/After（予告）を1行で表示（例: `FX Layer / Weight: 0 → 1`）。「修正」ボタンを押すと値がどう変わるかを事前に予告し、「直す力」を可視化
+
 ## [0.5.0] - 2026-04-28
 ### 追加
 - アバタールート指定時にチェックを自動実行するように変更（従来は「チェック実行」ボタン押下が必須。ボタンは引き続き手動再チェック用に利用可能）

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/AvatarOmamoriWindow.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/AvatarOmamoriWindow.cs
@@ -21,6 +21,7 @@ namespace AvatarOmamori.Editor
         private bool _foldError = true;
         private bool _foldWarning = true;
         private bool _foldInfo = true;
+        private bool _foldHistory = false; // 履歴はデフォルト閉じる（結果カードを優先）
 
         // GUIStyle のキャッシュ
         private GUIStyle _summaryStyle;
@@ -111,6 +112,12 @@ namespace AvatarOmamori.Editor
             if (_results.Count == 0)
             {
                 EditorGUILayout.HelpBox("問題は見つかりませんでした。", MessageType.Info);
+            }
+
+            if (FixHistoryStore.Count > 0)
+            {
+                EditorGUILayout.Space(6);
+                DrawFixHistoryGroup();
             }
 
             EditorGUILayout.EndScrollView();
@@ -225,6 +232,60 @@ namespace AvatarOmamori.Editor
                         result.ValueLabel, result.BeforeValue, result.AfterValue);
                     EditorGUILayout.EndHorizontal();
                 }
+
+                EditorGUILayout.EndVertical();
+                EditorGUILayout.Space(2);
+            }
+            EditorGUI.indentLevel--;
+        }
+
+        /// <summary>
+        /// セッション内の修正履歴（<see cref="FixHistoryStore"/>）を Foldout で表示する。
+        /// 新しい順に1件ずつ、修正対象の Ping ボタン付き。履歴クリアボタンは Foldout ヘッダ右端。
+        /// </summary>
+        private void DrawFixHistoryGroup()
+        {
+            var foldoutStyle = GetFoldoutStyle();
+            foldoutStyle.normal.textColor = new Color(0.6f, 0.6f, 0.6f);
+            foldoutStyle.onNormal.textColor = new Color(0.6f, 0.6f, 0.6f);
+
+            EditorGUILayout.BeginHorizontal();
+            _foldHistory = EditorGUILayout.Foldout(
+                _foldHistory, $"修正履歴 ({FixHistoryStore.Count})", true, foldoutStyle);
+            GUILayout.FlexibleSpace();
+            if (GUILayout.Button("クリア", GUILayout.Width(60)))
+            {
+                FixHistoryStore.Clear();
+                Repaint();
+            }
+            EditorGUILayout.EndHorizontal();
+
+            if (!_foldHistory) return;
+
+            EditorGUI.indentLevel++;
+            foreach (var entry in FixHistoryStore.Entries)
+            {
+                EditorGUILayout.BeginVertical("box");
+
+                EditorGUILayout.BeginHorizontal();
+                var header = $"[{entry.Timestamp:HH:mm:ss}] {entry.TargetObjectName}";
+                EditorGUILayout.LabelField(header, EditorStyles.miniLabel);
+                var target = EditorUtility.InstanceIDToObject(entry.TargetInstanceID);
+                using (new EditorGUI.DisabledScope(target == null))
+                {
+                    if (GUILayout.Button("Ping", GUILayout.Width(40)))
+                    {
+                        EditorGUIUtility.PingObject(target);
+                        Selection.activeObject = target;
+                    }
+                }
+                EditorGUILayout.EndHorizontal();
+
+                EditorGUILayout.BeginHorizontal();
+                GUILayout.Space(4f + EditorGUI.indentLevel * 15f);
+                OmamoriPopupStyles.DrawValueSnapshot(
+                    entry.ValueLabel, entry.BeforeValue, entry.AfterValue);
+                EditorGUILayout.EndHorizontal();
 
                 EditorGUILayout.EndVertical();
                 EditorGUILayout.Space(2);

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/AvatarOmamoriWindow.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/AvatarOmamoriWindow.cs
@@ -214,6 +214,18 @@ namespace AvatarOmamori.Editor
                 }
 
                 EditorGUILayout.EndHorizontal();
+
+                if (!string.IsNullOrEmpty(result.ValueLabel) &&
+                    (result.BeforeValue != null || result.AfterValue != null))
+                {
+                    EditorGUILayout.BeginHorizontal();
+                    // アイコン幅(20)+α + 上位の indentLevel 分(15px×段数) を加算してメッセージ本文の下に揃える
+                    GUILayout.Space(24f + EditorGUI.indentLevel * 15f);
+                    OmamoriPopupStyles.DrawValueSnapshot(
+                        result.ValueLabel, result.BeforeValue, result.AfterValue);
+                    EditorGUILayout.EndHorizontal();
+                }
+
                 EditorGUILayout.EndVertical();
                 EditorGUILayout.Space(2);
             }

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/CheckResult.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/CheckResult.cs
@@ -48,6 +48,18 @@ namespace AvatarOmamori.Editor
         /// </summary>
         public bool SkipConfirm { get; }
 
+        /// <summary>
+        /// Before/After 表示の項目名（例: "FX Layer / Weight"）。null なら結果カードに値の前後を表示しない。
+        /// 「直す力」を可視化する v0.6.0 の Before/After UI 用。
+        /// </summary>
+        public string ValueLabel { get; }
+
+        /// <summary>修正前の値の文字列表現（例: "0"）。null 可。</summary>
+        public string BeforeValue { get; }
+
+        /// <summary>修正後の値の文字列表現（例: "1"）。null 可。</summary>
+        public string AfterValue { get; }
+
         /// <summary>自動修正が利用可能かどうか。</summary>
         public bool HasFix => FixAction != null;
 
@@ -61,6 +73,9 @@ namespace AvatarOmamori.Editor
         /// <param name="fixLabel">修正ボタンの文言（任意）。null なら "修正"。</param>
         /// <param name="fixConfirmMessage">確認ダイアログ本文（任意）。null ならデフォルト文言。</param>
         /// <param name="skipConfirm">true にすると事前確認ダイアログを省略する（FixAction 側で独自にダイアログを出す場合用）。</param>
+        /// <param name="valueLabel">Before/After 表示用の項目名（任意）。例: "FX Layer / Weight"。</param>
+        /// <param name="beforeValue">修正前の値（任意）。例: "0"。</param>
+        /// <param name="afterValue">修正後の値（任意）。例: "1"。</param>
         public CheckResult(
             Severity severity,
             string message,
@@ -68,7 +83,10 @@ namespace AvatarOmamori.Editor
             Action fixAction = null,
             string fixLabel = null,
             string fixConfirmMessage = null,
-            bool skipConfirm = false)
+            bool skipConfirm = false,
+            string valueLabel = null,
+            string beforeValue = null,
+            string afterValue = null)
         {
             Severity = severity;
             Message = message;
@@ -77,6 +95,9 @@ namespace AvatarOmamori.Editor
             FixLabel = fixLabel;
             FixConfirmMessage = fixConfirmMessage;
             SkipConfirm = skipConfirm;
+            ValueLabel = valueLabel;
+            BeforeValue = beforeValue;
+            AfterValue = afterValue;
         }
     }
 }

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/AnimatorLayerWeightCheck.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/AnimatorLayerWeightCheck.cs
@@ -13,6 +13,9 @@ namespace AvatarOmamori.Editor.Checks
     /// </summary>
     public sealed class AnimatorLayerWeightCheck : IAvatarCheck
     {
+        // CheckResult の予告表示と FixHistoryEntry の実測記録で同じ文字列を共有するため定数化
+        private const string ValueLabel = "FX Layer / Weight";
+
         /// <inheritdoc/>
         public string DisplayName => "[SDK] Animator Layer Weight チェック";
 
@@ -62,9 +65,9 @@ namespace AvatarOmamori.Editor.Checks
                         Severity.Warning,
                         $"[SDK] FX レイヤー \"{layers[i].name}\" (index {i}) の Weight が 0 です。このレイヤーのアニメーションは反映されません。Weight を 1 に変更してください。",
                         descriptor,
-                        fixAction: () => SetLayerWeightToOne(capturedController, capturedIndex),
+                        fixAction: () => SetLayerWeightToOne(capturedController, capturedIndex, capturedName),
                         fixConfirmMessage: $"FXレイヤー「{capturedName}」のWeightを 0 → 1 に変更します。\nUndo（Ctrl+Z）で元に戻せます。",
-                        valueLabel: "FX Layer / Weight",
+                        valueLabel: ValueLabel,
                         beforeValue: "0",
                         afterValue: "1"
                     );
@@ -75,15 +78,30 @@ namespace AvatarOmamori.Editor.Checks
         /// <summary>
         /// 指定レイヤーの defaultWeight を 1 に設定する。
         /// AnimatorController.layers の getter はコピーを返すため、ローカル変数で変更してからセットし直す。
+        /// 修正直前/直後に実値を読んで <see cref="FixHistoryStore"/> に記録する（DEC-055 設計選択C）。
         /// </summary>
-        private static void SetLayerWeightToOne(AnimatorController controller, int layerIndex)
+        private static void SetLayerWeightToOne(AnimatorController controller, int layerIndex, string layerName)
         {
+            float before = controller.layers[layerIndex].defaultWeight;
+
             Undo.RecordObject(controller, "Fix Animator Layer Weight");
             var layers = controller.layers;
             layers[layerIndex].defaultWeight = 1f;
             controller.layers = layers;
             EditorUtility.SetDirty(controller);
             AssetDatabase.SaveAssets();
+
+            float after = controller.layers[layerIndex].defaultWeight;
+
+            FixHistoryStore.Record(new FixHistoryEntry(
+                timestamp: System.DateTime.Now,
+                checkName: nameof(AnimatorLayerWeightCheck),
+                valueLabel: ValueLabel,
+                beforeValue: before.ToString(),
+                afterValue: after.ToString(),
+                targetInstanceID: controller.GetInstanceID(),
+                targetObjectName: $"{controller.name} / \"{layerName}\" (Layer {layerIndex})"
+            ));
         }
 
         /// <summary>

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/AnimatorLayerWeightCheck.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/AnimatorLayerWeightCheck.cs
@@ -63,7 +63,10 @@ namespace AvatarOmamori.Editor.Checks
                         $"[SDK] FX レイヤー \"{layers[i].name}\" (index {i}) の Weight が 0 です。このレイヤーのアニメーションは反映されません。Weight を 1 に変更してください。",
                         descriptor,
                         fixAction: () => SetLayerWeightToOne(capturedController, capturedIndex),
-                        fixConfirmMessage: $"FXレイヤー「{capturedName}」のWeightを 0 → 1 に変更します。\nUndo（Ctrl+Z）で元に戻せます。"
+                        fixConfirmMessage: $"FXレイヤー「{capturedName}」のWeightを 0 → 1 に変更します。\nUndo（Ctrl+Z）で元に戻せます。",
+                        valueLabel: "FX Layer / Weight",
+                        beforeValue: "0",
+                        afterValue: "1"
                     );
                 }
             }

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/DescriptorDuplicateCheck.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/DescriptorDuplicateCheck.cs
@@ -39,7 +39,10 @@ namespace AvatarOmamori.Editor.Checks
                 fixAction: () => ShowResolveWindow(avatarRoot, descriptors),
                 fixLabel: null,                    // 共通「修正」で統一
                 fixConfirmMessage: null,           // SkipConfirm=true のとき未使用
-                skipConfirm: true                  // 独自の選択ウィンドウを出すので事前確認・自動再チェックともスキップ
+                skipConfirm: true,                 // 独自の選択ウィンドウを出すので事前確認・自動再チェックともスキップ
+                valueLabel: "Avatar Descriptor",
+                beforeValue: $"Descriptor×{descriptors.Length}個",
+                afterValue: "1個"
             );
 
             // 各重複箇所も検出行として報告（FixAction はサマリー側に集約済み）

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/DescriptorDuplicateCheck.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/DescriptorDuplicateCheck.cs
@@ -12,6 +12,9 @@ namespace AvatarOmamori.Editor.Checks
     /// </summary>
     public sealed class DescriptorDuplicateCheck : IAvatarCheck
     {
+        // CheckResult の予告表示と FixHistoryEntry の実測記録で同じ文字列を共有するため定数化
+        private const string ValueLabel = "Avatar Descriptor";
+
         /// <inheritdoc/>
         public string DisplayName => "VRC Avatar Descriptor 重複チェック";
 
@@ -40,7 +43,7 @@ namespace AvatarOmamori.Editor.Checks
                 fixLabel: null,                    // 共通「修正」で統一
                 fixConfirmMessage: null,           // SkipConfirm=true のとき未使用
                 skipConfirm: true,                 // 独自の選択ウィンドウを出すので事前確認・自動再チェックともスキップ
-                valueLabel: "Avatar Descriptor",
+                valueLabel: ValueLabel,
                 beforeValue: $"Descriptor×{descriptors.Length}個",
                 afterValue: "1個"
             );
@@ -66,7 +69,7 @@ namespace AvatarOmamori.Editor.Checks
         {
             DescriptorChoiceWindow.Show(avatarRoot, descriptors, keep =>
             {
-                RemoveAllExcept(descriptors, keep);
+                RemoveAllExcept(descriptors, keep, avatarRoot);
                 RefreshOmamoriWindow();
             });
         }
@@ -75,11 +78,15 @@ namespace AvatarOmamori.Editor.Checks
         /// <paramref name="keep"/> 以外の Descriptor を一括削除する。
         /// 複数削除を1つの Undo 単位にまとめ、Ctrl+Z で一度に戻せるようにする。
         /// GameObject ごと削除すると他のコンポーネントや子を巻き込むので、コンポーネントだけを削除する。
+        /// 修正直前/直後に実数を読んで <see cref="FixHistoryStore"/> に記録する（DEC-055 設計選択C）。
         /// </summary>
         private static void RemoveAllExcept(
             VRCAvatarDescriptor[] all,
-            VRCAvatarDescriptor keep)
+            VRCAvatarDescriptor keep,
+            GameObject avatarRoot)
         {
+            int before = all.Length;
+
             Undo.IncrementCurrentGroup();
             Undo.SetCurrentGroupName("Resolve Duplicate VRC Avatar Descriptors");
             int group = Undo.GetCurrentGroup();
@@ -93,6 +100,23 @@ namespace AvatarOmamori.Editor.Checks
             }
 
             Undo.CollapseUndoOperations(group);
+
+            // Undo.DestroyObjectImmediate 後の参照は Unity の "fake null" になるので、d != null で生存数を数えられる
+            int after = 0;
+            foreach (var d in all)
+            {
+                if (d != null) after++;
+            }
+
+            FixHistoryStore.Record(new FixHistoryEntry(
+                timestamp: System.DateTime.Now,
+                checkName: nameof(DescriptorDuplicateCheck),
+                valueLabel: ValueLabel,
+                beforeValue: $"Descriptor×{before}個",
+                afterValue: $"{after}個",
+                targetInstanceID: avatarRoot.GetInstanceID(),
+                targetObjectName: avatarRoot.name
+            ));
         }
 
         /// <summary>

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/MissingScriptCheck.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/MissingScriptCheck.cs
@@ -12,6 +12,9 @@ namespace AvatarOmamori.Editor.Checks
     /// </summary>
     public sealed class MissingScriptCheck : IAvatarCheck
     {
+        // CheckResult の予告表示と FixHistoryEntry の実測記録で同じ文字列を共有するため定数化
+        private const string ValueLabel = "Missing Script";
+
         /// <inheritdoc/>
         public string DisplayName => "[Unity] Missing Script チェック";
 
@@ -46,7 +49,7 @@ namespace AvatarOmamori.Editor.Checks
                             $"「{capturedGo.name}」から Missing Script を {capturedCount} 個削除します。\n" +
                             "※この操作は Undo（Ctrl+Z）で元に戻せません。\n" +
                             "Missing Script はすでにスクリプト参照が壊れているコンポーネントなので、削除しても実質的なデータ損失はありません。",
-                        valueLabel: "Missing Script",
+                        valueLabel: ValueLabel,
                         beforeValue: $"Missing×{capturedCount}個",
                         afterValue: "0個"
                     );
@@ -69,6 +72,8 @@ namespace AvatarOmamori.Editor.Checks
         /// </remarks>
         private static void RemoveMissingScripts(GameObject target)
         {
+            int before = GameObjectUtility.GetMonoBehavioursWithMissingScriptCount(target);
+
             GameObjectUtility.RemoveMonoBehavioursWithMissingScript(target);
             EditorUtility.SetDirty(target);
 
@@ -79,6 +84,18 @@ namespace AvatarOmamori.Editor.Checks
             {
                 EditorSceneManager.MarkSceneDirty(scene);
             }
+
+            int after = GameObjectUtility.GetMonoBehavioursWithMissingScriptCount(target);
+
+            FixHistoryStore.Record(new FixHistoryEntry(
+                timestamp: System.DateTime.Now,
+                checkName: nameof(MissingScriptCheck),
+                valueLabel: ValueLabel,
+                beforeValue: $"Missing×{before}個",
+                afterValue: $"{after}個",
+                targetInstanceID: target.GetInstanceID(),
+                targetObjectName: target.name
+            ));
         }
     }
 }

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/MissingScriptCheck.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/MissingScriptCheck.cs
@@ -45,7 +45,10 @@ namespace AvatarOmamori.Editor.Checks
                         fixConfirmMessage:
                             $"「{capturedGo.name}」から Missing Script を {capturedCount} 個削除します。\n" +
                             "※この操作は Undo（Ctrl+Z）で元に戻せません。\n" +
-                            "Missing Script はすでにスクリプト参照が壊れているコンポーネントなので、削除しても実質的なデータ損失はありません。"
+                            "Missing Script はすでにスクリプト参照が壊れているコンポーネントなので、削除しても実質的なデータ損失はありません。",
+                        valueLabel: "Missing Script",
+                        beforeValue: $"Missing×{capturedCount}個",
+                        afterValue: "0個"
                     );
                 }
             }

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/FixHistoryEntry.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/FixHistoryEntry.cs
@@ -1,0 +1,57 @@
+using System;
+
+namespace AvatarOmamori.Editor
+{
+    /// <summary>
+    /// 自動修正が1回実行されたことを記録する不変エントリ。
+    /// FixAction の中で修正直前/直後の値を実測し、<see cref="FixHistoryStore"/> に積む。
+    /// CheckResult の Before/After（構築時セットの「予告値」）とは別物で、
+    /// fix 失敗や別ウィンドウでの手動変更で予告と実測が乖離した場合に、実測側を残すのが目的（DEC-055 選択C）。
+    /// </summary>
+    public sealed class FixHistoryEntry
+    {
+        /// <summary>修正が実行された時刻。</summary>
+        public DateTime Timestamp { get; }
+
+        /// <summary>修正を実行した Check の識別名（例: "AnimatorLayerWeightCheck"）。</summary>
+        public string CheckName { get; }
+
+        /// <summary>表示用の値ラベル（例: "FX Layer / Weight"）。</summary>
+        public string ValueLabel { get; }
+
+        /// <summary>修正直前に実測した値の文字列表現。</summary>
+        public string BeforeValue { get; }
+
+        /// <summary>修正直後に実測した値の文字列表現。</summary>
+        public string AfterValue { get; }
+
+        /// <summary>
+        /// 修正対象オブジェクトの InstanceID。Ping のときに <see cref="UnityEditor.EditorUtility.InstanceIDToObject"/>
+        /// で復元する。シーン切替や対象削除で 0 を返すようになることがある。
+        /// </summary>
+        public int TargetInstanceID { get; }
+
+        /// <summary>
+        /// 修正対象オブジェクトの名前。InstanceID から復元できなくなったときの表示フォールバック用。
+        /// </summary>
+        public string TargetObjectName { get; }
+
+        public FixHistoryEntry(
+            DateTime timestamp,
+            string checkName,
+            string valueLabel,
+            string beforeValue,
+            string afterValue,
+            int targetInstanceID,
+            string targetObjectName)
+        {
+            Timestamp = timestamp;
+            CheckName = checkName;
+            ValueLabel = valueLabel;
+            BeforeValue = beforeValue;
+            AfterValue = afterValue;
+            TargetInstanceID = targetInstanceID;
+            TargetObjectName = targetObjectName;
+        }
+    }
+}

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/FixHistoryEntry.cs.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/FixHistoryEntry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2b24c9eb3b2244de836763e2b05444fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/FixHistoryStore.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/FixHistoryStore.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AvatarOmamori.Editor
+{
+    /// <summary>
+    /// セッション内の自動修正履歴を保持するプロセスローカルのストア。
+    /// FixAction クロージャからインスタンス参照なしで Record できるよう static にしている。
+    /// アバター切替ではクリアしない（DEC-055 設計選択C）。
+    /// Editor プロセス終了で消える（永続化しない）。
+    /// </summary>
+    internal static class FixHistoryStore
+    {
+        private const int MaxEntries = 100;
+
+        // 古い順に push、上限超過で先頭から捨てる。表示は新しい順に返すので Entries で反転する
+        private static readonly List<FixHistoryEntry> _entries = new List<FixHistoryEntry>();
+
+        /// <summary>現在保持している履歴件数。</summary>
+        public static int Count => _entries.Count;
+
+        /// <summary>新しい順の履歴。</summary>
+        public static IEnumerable<FixHistoryEntry> Entries => _entries.AsEnumerable().Reverse();
+
+        /// <summary>履歴に1件追加する。上限超過時は最古を捨てる。</summary>
+        public static void Record(FixHistoryEntry entry)
+        {
+            if (entry == null) return;
+            _entries.Add(entry);
+            if (_entries.Count > MaxEntries)
+            {
+                _entries.RemoveAt(0);
+            }
+        }
+
+        /// <summary>履歴を全消去する（UI からのクリア操作用）。</summary>
+        public static void Clear()
+        {
+            _entries.Clear();
+        }
+    }
+}

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/FixHistoryStore.cs.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/FixHistoryStore.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 646d9d2b0370489591e437b6b9f682a7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/OmamoriPopupStyles.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/OmamoriPopupStyles.cs
@@ -46,6 +46,26 @@ namespace AvatarOmamori.Editor
         }
 
         /// <summary>
+        /// 自動修正の Before/After（予告値）を <see cref="EditorStyles.miniLabel"/> で1行描画する。
+        /// 両方あれば "{label}: {before} → {after}"、片方のみは矢印なしで "{label}: {value}"。
+        /// label が空、または before/after が両方 null なら何も描画しない。
+        /// </summary>
+        public static void DrawValueSnapshot(string label, string before, string after)
+        {
+            if (string.IsNullOrEmpty(label)) return;
+            bool hasBefore = before != null;
+            bool hasAfter = after != null;
+            if (!hasBefore && !hasAfter) return;
+
+            string body;
+            if (hasBefore && hasAfter) body = $"{before} → {after}";
+            else if (hasBefore) body = before;
+            else body = after;
+
+            GUILayout.Label($"{label}: {body}", EditorStyles.miniLabel);
+        }
+
+        /// <summary>
         /// <see cref="DrawInfoBox"/> で描画した場合の想定高さ（概算）。
         /// 明示的な改行数に応じて計算する（折り返しは考慮しないが、ウィンドウ幅が十分広ければ問題ない）。
         /// </summary>


### PR DESCRIPTION
## 概要

v0.6.0「見える価値化」W1（DEC-055）。自動修正の「直す力」を見える形にする2機能。

## 含まれる変更

### Before/After UI（T-2〜T-4・コミット d6d2958）
- `CheckResult` に `ValueLabel` / `BeforeValue` / `AfterValue`（immutable・構築時セットの「予告」値）を追加
- Animator Layer Weight / Missing Script / VRC Avatar Descriptor 重複の3項目で修正前後の値を保持
- 結果カードに Before/After を1行表示（例: `FX Layer / Weight: 0 → 1`）

### 修正履歴 Foldout（T-5・本コミット）
- `FixHistoryEntry` / `FixHistoryStore`（上限100件・FIFO・新しい順表示）を追加
- 各 fix メソッドで**修正直前/直後の実測値**を `Record`（予告値のコピーではなく実測。設計選択C）
- `AvatarOmamoriWindow` に「修正履歴」Foldout（Ping ボタン・クリアボタン付き）
- アバター切替時はクリアしない／EditorWindow 終了で消える（永続化なし＝DEC-055 B1）

## 設計メモ
- 結果カード=予告値（CheckResult 構築時）、修正履歴=FixAction 内の実測値、という二層構成。fix 失敗や別ウィンドウでの手動変更で予告と実測が乖離しても実測側を残せる

## テスト
- ⚠️ Unity 実機確認はレビュー後／マージ前に実施予定（progress/omamori.md の W1 メモ参照）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
