### PR TITLE
テスト基盤の導入と EditMode テスト一式（#20 / #21 / #22）

### DIFF
--- a/Packages/com.tsukumodo.avatar-omamori/Editor/AssemblyInfo.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+// internal メンバー（SanitizeKey・FixHistoryStore 等）を EditMode テストから検証できるようにする
+[assembly: InternalsVisibleTo("com.tsukumodo.avatar-omamori.tests.editor")]

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/AssemblyInfo.cs.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a483626b3c8b95d06826838fb992fcaf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/CheckRunner.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/CheckRunner.cs
@@ -33,12 +33,21 @@ namespace AvatarOmamori.Editor
         /// <returns>全チェックの結果を集約したリスト。</returns>
         public static List<CheckResult> RunAll(GameObject avatarRoot)
         {
+            return RunAll(avatarRoot, Checks);
+        }
+
+        /// <summary>
+        /// 指定されたチェック群を実行する本体。
+        /// テストからフェイクチェックを注入して例外分離などを検証できるよう分離している。
+        /// </summary>
+        internal static List<CheckResult> RunAll(GameObject avatarRoot, IEnumerable<IAvatarCheck> checks)
+        {
             var results = new List<CheckResult>();
             // チェック種別ごとの検出件数（利用統計用）。キーはチェッククラスの型名のみを使い、
             // ユーザーのアセット名などは一切載せない（個人情報を集めない設計・DEC-055）。
             var detectionsByCheckType = new Dictionary<string, int>();
 
-            foreach (var check in Checks)
+            foreach (var check in checks)
             {
                 if (!check.IsAvailable())
                     continue;

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/UsageStatsRecorder.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/UsageStatsRecorder.cs
@@ -40,6 +40,21 @@ namespace AvatarOmamori.Editor
         private static UsageStats s_cache;
         private static string s_toolVersionCache;
 
+        /// <summary>
+        /// テスト専用: 保存先ディレクトリの上書き。null なら通常パス（Library/ 配下）。
+        /// テストが実プロジェクトの統計ファイルを汚さないための口。製品コードから設定しないこと。
+        /// </summary>
+        internal static string StatsDirOverrideForTests;
+
+        /// <summary>
+        /// テスト専用: プロセス内キャッシュを破棄し、次回アクセス時にディスクから再読込させる。
+        /// </summary>
+        internal static void ResetForTests()
+        {
+            s_cache = null;
+            s_toolVersionCache = null;
+        }
+
         // ───────────────────────────── 記録 API ─────────────────────────────
 
         /// <summary>
@@ -220,7 +235,7 @@ namespace AvatarOmamori.Editor
         /// キーを ASCII 識別子（英数字とアンダースコア）に限定する。条件を満たさなければ null。
         /// 個人情報（アバター名・パス・日本語など）がキーとして保存されるのを構造的に防ぐ最終防波堤。
         /// </summary>
-        private static string SanitizeKey(string raw)
+        internal static string SanitizeKey(string raw)
         {
             if (string.IsNullOrEmpty(raw)) return null;
             if (raw.Length > MaxKeyLength) return null;
@@ -254,6 +269,8 @@ namespace AvatarOmamori.Editor
 
         private static string StatsDir()
         {
+            if (!string.IsNullOrEmpty(StatsDirOverrideForTests)) return StatsDirOverrideForTests;
+
             // Application.dataPath は "<project>/Assets"。その親が <project>、さらに Library を足す。
             var projectRoot = Path.GetDirectoryName(Application.dataPath);
             return Path.Combine(projectRoot, "Library", PackageFolderName);

--- a/Packages/com.tsukumodo.avatar-omamori/Tests.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 15f227d0800aff5d7316ec8b70dcfad2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 82269baafc7f6bc958519bce5a3cf3e6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/AnimatorLayerWeightCheckTests.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/AnimatorLayerWeightCheckTests.cs
@@ -1,0 +1,104 @@
+using System.Linq;
+using NUnit.Framework;
+using UnityEditor.Animations;
+using UnityEngine;
+using VRC.SDK3.Avatars.Components;
+using AvatarOmamori.Editor;
+using AvatarOmamori.Editor.Checks;
+
+namespace AvatarOmamori.Tests.Editor
+{
+    public class AnimatorLayerWeightCheckTests
+    {
+        private string _statsDir;
+        private GameObject _root;
+        private AnimatorController _controller;
+        private readonly AnimatorLayerWeightCheck _check = new AnimatorLayerWeightCheck();
+
+        [SetUp]
+        public void SetUp()
+        {
+            // FixAction が利用統計を記録するため、保存先を一時フォルダへ退避する
+            _statsDir = UsageStatsTestUtil.BeginOverride();
+            FixHistoryStore.Clear();
+            _root = new GameObject("Avatar");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            UsageStatsTestUtil.EndOverride(_statsDir);
+            FixHistoryStore.Clear();
+            if (_controller != null) Object.DestroyImmediate(_controller);
+            if (_root != null) Object.DestroyImmediate(_root);
+        }
+
+        /// <summary>
+        /// 指定した weight 配列のレイヤーを持つ FX コントローラーを組み立てて Descriptor に設定する。
+        /// </summary>
+        private void SetupFxLayer(bool isDefault, params float[] weights)
+        {
+            _controller = new AnimatorController();
+            for (int i = 0; i < weights.Length; i++)
+            {
+                _controller.AddLayer($"Layer{i}");
+            }
+            var layers = _controller.layers; // getter はコピーを返すため、変更してからセットし直す
+            for (int i = 0; i < weights.Length; i++)
+            {
+                layers[i].defaultWeight = weights[i];
+            }
+            _controller.layers = layers;
+
+            var descriptor = _root.AddComponent<VRCAvatarDescriptor>();
+            descriptor.baseAnimationLayers = new[]
+            {
+                new VRCAvatarDescriptor.CustomAnimLayer
+                {
+                    type = VRCAvatarDescriptor.AnimLayerType.FX,
+                    isDefault = isDefault,
+                    animatorController = _controller,
+                },
+            };
+        }
+
+        [Test]
+        public void Weight0のFXレイヤーを警告し修正で1になる()
+        {
+            SetupFxLayer(isDefault: false, 1f, 0f);
+
+            var results = _check.Execute(_root).ToList();
+
+            Assert.AreEqual(1, results.Count);
+            var result = results[0];
+            Assert.AreEqual(Severity.Warning, result.Severity);
+            Assert.That(result.Message, Does.Contain("Layer1"));
+            Assert.IsTrue(result.HasFix);
+            Assert.AreEqual("0", result.BeforeValue);
+            Assert.AreEqual("1", result.AfterValue);
+
+            result.FixAction();
+
+            Assert.AreEqual(1f, _controller.layers[1].defaultWeight, "修正後も Weight が 0 のまま");
+            Assert.IsEmpty(_check.Execute(_root).ToList());
+            Assert.AreEqual(1, FixHistoryStore.Count, "修正履歴が記録されていない");
+        }
+
+        [Test]
+        public void ベースレイヤーのWeight0は検出しない()
+        {
+            // index 0 は常に Weight=1 で動作する仕様のためチェック対象外
+            SetupFxLayer(isDefault: false, 0f, 1f);
+
+            Assert.IsEmpty(_check.Execute(_root).ToList());
+        }
+
+        [Test]
+        public void isDefaultのFXレイヤーは検出しない()
+        {
+            SetupFxLayer(isDefault: true, 1f, 0f);
+
+            Assert.IsEmpty(_check.Execute(_root).ToList());
+        }
+    }
+}

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/AnimatorLayerWeightCheckTests.cs.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/AnimatorLayerWeightCheckTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7cf0c8141bee2b321d7cfe79e2c95622
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/CheckRunnerDiscoveryTests.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/CheckRunnerDiscoveryTests.cs
@@ -1,0 +1,35 @@
+using System.Linq;
+using NUnit.Framework;
+using AvatarOmamori.Editor;
+
+namespace AvatarOmamori.Tests.Editor
+{
+    public class CheckRunnerDiscoveryTests
+    {
+        [Test]
+        public void Checks_実装済みの9チェックが全て検出される()
+        {
+            // Checks はアセンブリ内の IAvatarCheck 実装をリフレクション列挙するだけで
+            // IsAvailable() は見ないため、MA 未インストール環境でも9件全てが列挙される
+            var names = CheckRunner.Checks.Select(c => c.GetType().Name).ToList();
+
+            var expected = new[]
+            {
+                "DescriptorDuplicateCheck",
+                "MissingScriptCheck",
+                "MissingShaderCheck",
+                "EmptyParameterNameCheck",
+                "ExpressionParameterBitLimitCheck",
+                "AnimatorLayerWeightCheck",
+                "MAMenuItemUnboundCheck",
+                "MAObjectToggleCheck",
+                "MAUnsetupAccessoryCheck",
+            };
+
+            foreach (var name in expected)
+            {
+                Assert.That(names, Does.Contain(name), $"{name} が CheckRunner.Checks に含まれていない");
+            }
+        }
+    }
+}

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/CheckRunnerDiscoveryTests.cs.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/CheckRunnerDiscoveryTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f9e66d560343b3289dd190b110b60366
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/CheckRunnerRunAllTests.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/CheckRunnerRunAllTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using AvatarOmamori.Editor;
+
+namespace AvatarOmamori.Tests.Editor
+{
+    public class CheckRunnerRunAllTests
+    {
+        private string _statsDir;
+        private GameObject _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            // RunAll は利用統計を記録するため、保存先を一時フォルダへ退避する
+            _statsDir = UsageStatsTestUtil.BeginOverride();
+            _root = new GameObject("Avatar");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            UsageStatsTestUtil.EndOverride(_statsDir);
+            if (_root != null) UnityEngine.Object.DestroyImmediate(_root);
+        }
+
+        [Test]
+        public void RunAll_例外を投げるチェックがあっても他のチェックは実行される()
+        {
+            var normal = new FakeCheck();
+            var checks = new IAvatarCheck[] { new ThrowingCheck(), normal };
+
+            LogAssert.Expect(LogType.Warning, new Regex("ThrowingCheck"));
+            var results = CheckRunner.RunAll(_root, checks);
+
+            Assert.AreEqual(1, results.Count);
+            Assert.AreEqual("fake", results[0].Message);
+            Assert.IsTrue(normal.Executed);
+        }
+
+        [Test]
+        public void RunAll_IsAvailableがfalseのチェックは実行されない()
+        {
+            var unavailable = new FakeCheck { Available = false };
+
+            var results = CheckRunner.RunAll(_root, new IAvatarCheck[] { unavailable });
+
+            Assert.IsEmpty(results);
+            Assert.IsFalse(unavailable.Executed);
+        }
+
+        // ネストした private クラスなので CheckRunner.DiscoverChecks（メインアセンブリのみ走査）には
+        // 拾われず、本物のチェック一覧を汚さない
+        private sealed class FakeCheck : IAvatarCheck
+        {
+            public bool Available = true;
+            public bool Executed;
+
+            public string DisplayName => "Fake";
+
+            public bool IsAvailable() => Available;
+
+            public IEnumerable<CheckResult> Execute(GameObject avatarRoot)
+            {
+                Executed = true;
+                return new[] { new CheckResult(Severity.Info, "fake") };
+            }
+        }
+
+        private sealed class ThrowingCheck : IAvatarCheck
+        {
+            public string DisplayName => "ThrowingCheck";
+
+            public bool IsAvailable() => true;
+
+            public IEnumerable<CheckResult> Execute(GameObject avatarRoot)
+            {
+                throw new InvalidOperationException("boom");
+            }
+        }
+    }
+}

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/CheckRunnerRunAllTests.cs.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/CheckRunnerRunAllTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6203494b8ffe6b8f2cbb16d496ffda6c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/DescriptorDuplicateCheckTests.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/DescriptorDuplicateCheckTests.cs
@@ -1,0 +1,55 @@
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using VRC.SDK3.Avatars.Components;
+using AvatarOmamori.Editor;
+using AvatarOmamori.Editor.Checks;
+
+namespace AvatarOmamori.Tests.Editor
+{
+    public class DescriptorDuplicateCheckTests
+    {
+        private GameObject _root;
+        private readonly DescriptorDuplicateCheck _check = new DescriptorDuplicateCheck();
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_root != null) Object.DestroyImmediate(_root);
+        }
+
+        [Test]
+        public void Descriptorが1個なら検出しない()
+        {
+            _root = new GameObject("Avatar");
+            _root.AddComponent<VRCAvatarDescriptor>();
+
+            Assert.IsEmpty(_check.Execute(_root).ToList());
+        }
+
+        [Test]
+        public void Descriptorが2個ならサマリーと重複箇所の2件を検出する()
+        {
+            _root = new GameObject("Avatar");
+            _root.AddComponent<VRCAvatarDescriptor>();
+            var child = new GameObject("Child");
+            child.transform.SetParent(_root.transform);
+            child.AddComponent<VRCAvatarDescriptor>();
+
+            var results = _check.Execute(_root).ToList();
+
+            Assert.AreEqual(2, results.Count);
+
+            var summary = results[0];
+            Assert.AreEqual(Severity.Error, summary.Severity);
+            Assert.That(summary.Message, Does.Contain("2 個"));
+            Assert.IsTrue(summary.HasFix, "サマリー結果に修正アクションが付いていない");
+            Assert.IsTrue(summary.SkipConfirm, "選択ウィンドウを出す修正は SkipConfirm であるべき");
+
+            var duplicate = results[1];
+            Assert.AreEqual(Severity.Error, duplicate.Severity);
+            Assert.That(duplicate.Message, Does.Contain("Avatar/Child"));
+            Assert.IsFalse(duplicate.HasFix, "重複箇所の結果に修正アクションは付かない（サマリーに集約）");
+        }
+    }
+}

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/DescriptorDuplicateCheckTests.cs.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/DescriptorDuplicateCheckTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e53c245c10f1d6962d57b46636912340
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/DummyBehaviour.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/DummyBehaviour.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+namespace AvatarOmamori.Tests.Editor
+{
+    /// <summary>
+    /// MissingScriptCheck のテストフィクスチャ生成用の空 MonoBehaviour。
+    /// Prefab に保存した後、スクリプト GUID を書き換えて Missing Script 化する。
+    /// </summary>
+    public sealed class DummyBehaviour : MonoBehaviour
+    {
+    }
+}

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/DummyBehaviour.cs.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/DummyBehaviour.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1b80f69f820cfb5e634f3f7f35e41497
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/EmptyParameterNameCheckTests.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/EmptyParameterNameCheckTests.cs
@@ -1,0 +1,96 @@
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using VRC.SDK3.Avatars.Components;
+using VRC.SDK3.Avatars.ScriptableObjects;
+using AvatarOmamori.Editor;
+using AvatarOmamori.Editor.Checks;
+
+namespace AvatarOmamori.Tests.Editor
+{
+    public class EmptyParameterNameCheckTests
+    {
+        private GameObject _root;
+        private VRCAvatarDescriptor _descriptor;
+        private VRCExpressionsMenu _menu;
+        private VRCExpressionParameters _parameters;
+        private readonly EmptyParameterNameCheck _check = new EmptyParameterNameCheck();
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new GameObject("Avatar");
+            _descriptor = _root.AddComponent<VRCAvatarDescriptor>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_menu != null) Object.DestroyImmediate(_menu);
+            if (_parameters != null) Object.DestroyImmediate(_parameters);
+            if (_root != null) Object.DestroyImmediate(_root);
+        }
+
+        private static VRCExpressionParameters.Parameter Param(string name)
+        {
+            return new VRCExpressionParameters.Parameter
+            {
+                name = name,
+                valueType = VRCExpressionParameters.ValueType.Bool,
+                networkSynced = true,
+            };
+        }
+
+        [Test]
+        public void Descriptorがなければ検出しない()
+        {
+            var plain = new GameObject("NoDescriptor");
+            try
+            {
+                Assert.IsEmpty(_check.Execute(plain).ToList());
+            }
+            finally
+            {
+                Object.DestroyImmediate(plain);
+            }
+        }
+
+        [Test]
+        public void MenuがあるのにParametersが未設定なら警告する()
+        {
+            _menu = ScriptableObject.CreateInstance<VRCExpressionsMenu>();
+            _descriptor.expressionsMenu = _menu;
+            _descriptor.expressionParameters = null;
+
+            var results = _check.Execute(_root).ToList();
+
+            Assert.AreEqual(1, results.Count);
+            Assert.AreEqual(Severity.Warning, results[0].Severity);
+            Assert.That(results[0].Message, Does.Contain("Expression Parameters が未設定"));
+        }
+
+        [Test]
+        public void 名前が空のエントリを添字付きで警告する()
+        {
+            _parameters = ScriptableObject.CreateInstance<VRCExpressionParameters>();
+            _parameters.parameters = new[] { Param("Valid"), Param("") };
+            _descriptor.expressionParameters = _parameters;
+
+            var results = _check.Execute(_root).ToList();
+
+            Assert.AreEqual(1, results.Count);
+            Assert.AreEqual(Severity.Warning, results[0].Severity);
+            Assert.That(results[0].Message, Does.Contain("[1]"));
+        }
+
+        [Test]
+        public void 全エントリに名前があれば検出しない()
+        {
+            _parameters = ScriptableObject.CreateInstance<VRCExpressionParameters>();
+            _parameters.parameters = new[] { Param("A"), Param("B") };
+            _descriptor.expressionParameters = _parameters;
+
+            Assert.IsEmpty(_check.Execute(_root).ToList());
+        }
+    }
+}

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/EmptyParameterNameCheckTests.cs.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/EmptyParameterNameCheckTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 932132ba56c99f38885e681c11a34bed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/ExpressionParameterBitLimitCheckTests.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/ExpressionParameterBitLimitCheckTests.cs
@@ -1,0 +1,93 @@
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using VRC.SDK3.Avatars.Components;
+using VRC.SDK3.Avatars.ScriptableObjects;
+using AvatarOmamori.Editor;
+using AvatarOmamori.Editor.Checks;
+
+namespace AvatarOmamori.Tests.Editor
+{
+    public class ExpressionParameterBitLimitCheckTests
+    {
+        private GameObject _root;
+        private VRCExpressionParameters _parameters;
+        private readonly ExpressionParameterBitLimitCheck _check = new ExpressionParameterBitLimitCheck();
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new GameObject("Avatar");
+            var descriptor = _root.AddComponent<VRCAvatarDescriptor>();
+            _parameters = ScriptableObject.CreateInstance<VRCExpressionParameters>();
+            descriptor.expressionParameters = _parameters;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_parameters != null) Object.DestroyImmediate(_parameters);
+            if (_root != null) Object.DestroyImmediate(_root);
+        }
+
+        private static VRCExpressionParameters.Parameter Param(
+            VRCExpressionParameters.ValueType type, bool synced, int index)
+        {
+            return new VRCExpressionParameters.Parameter
+            {
+                name = $"p{index}",
+                valueType = type,
+                networkSynced = synced,
+            };
+        }
+
+        [Test]
+        public void 上限ちょうど256bitは検出しない()
+        {
+            // Float は 8bit なので 32 個でちょうど 256bit
+            _parameters.parameters = Enumerable.Range(0, 32)
+                .Select(i => Param(VRCExpressionParameters.ValueType.Float, true, i))
+                .ToArray();
+
+            Assert.IsEmpty(_check.Execute(_root).ToList());
+        }
+
+        [Test]
+        public void 上限超過264bitをエラーとして検出する()
+        {
+            _parameters.parameters = Enumerable.Range(0, 33)
+                .Select(i => Param(VRCExpressionParameters.ValueType.Float, true, i))
+                .ToArray();
+
+            var results = _check.Execute(_root).ToList();
+
+            Assert.AreEqual(1, results.Count);
+            Assert.AreEqual(Severity.Error, results[0].Severity);
+            Assert.That(results[0].Message, Does.Contain("264 / 256"));
+        }
+
+        [Test]
+        public void 非同期パラメータはビット数に数えない()
+        {
+            // Float 33個のうち1個を非同期にすると同期分は 256bit ちょうどに収まる
+            _parameters.parameters = Enumerable.Range(0, 33)
+                .Select(i => Param(VRCExpressionParameters.ValueType.Float, synced: i != 0, index: i))
+                .ToArray();
+
+            Assert.IsEmpty(_check.Execute(_root).ToList());
+        }
+
+        [Test]
+        public void Boolは1bitとして数える()
+        {
+            _parameters.parameters = Enumerable.Range(0, 257)
+                .Select(i => Param(VRCExpressionParameters.ValueType.Bool, true, i))
+                .ToArray();
+
+            var results = _check.Execute(_root).ToList();
+
+            Assert.AreEqual(1, results.Count);
+            Assert.That(results[0].Message, Does.Contain("257 / 256"));
+        }
+    }
+}

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/ExpressionParameterBitLimitCheckTests.cs.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/ExpressionParameterBitLimitCheckTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c66e85fd07fde8ede92f4623e8d01932
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/HierarchyPathUtilTests.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/HierarchyPathUtilTests.cs
@@ -1,0 +1,37 @@
+using NUnit.Framework;
+using UnityEngine;
+using AvatarOmamori.Editor.Util;
+
+namespace AvatarOmamori.Tests.Editor
+{
+    public class HierarchyPathUtilTests
+    {
+        private GameObject _root;
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_root != null) Object.DestroyImmediate(_root);
+        }
+
+        [Test]
+        public void GetHierarchyPath_3階層のパスをスラッシュ区切りで返す()
+        {
+            _root = new GameObject("Root");
+            var child = new GameObject("Child");
+            child.transform.SetParent(_root.transform);
+            var target = new GameObject("Target");
+            target.transform.SetParent(child.transform);
+
+            Assert.AreEqual("Root/Child/Target", HierarchyPathUtil.GetHierarchyPath(target));
+        }
+
+        [Test]
+        public void GetHierarchyPath_ルート単体は名前のみを返す()
+        {
+            _root = new GameObject("Root");
+
+            Assert.AreEqual("Root", HierarchyPathUtil.GetHierarchyPath(_root));
+        }
+    }
+}

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/HierarchyPathUtilTests.cs.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/HierarchyPathUtilTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 25c8afd062399efa7e8720d8a1206f63
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/MissingScriptCheckTests.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/MissingScriptCheckTests.cs
@@ -1,0 +1,85 @@
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using AvatarOmamori.Editor;
+using AvatarOmamori.Editor.Checks;
+
+namespace AvatarOmamori.Tests.Editor
+{
+    public class MissingScriptCheckTests
+    {
+        private const string PrefabPath = "Assets/__omamori_missing_script_fixture.prefab";
+
+        private string _statsDir;
+        private GameObject _instance;
+        private readonly MissingScriptCheck _check = new MissingScriptCheck();
+
+        [SetUp]
+        public void SetUp()
+        {
+            // FixAction が利用統計を記録するため、保存先を一時フォルダへ退避する
+            _statsDir = UsageStatsTestUtil.BeginOverride();
+            FixHistoryStore.Clear();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            UsageStatsTestUtil.EndOverride(_statsDir);
+            FixHistoryStore.Clear();
+            if (_instance != null) Object.DestroyImmediate(_instance);
+            AssetDatabase.DeleteAsset(PrefabPath);
+        }
+
+        [Test]
+        public void MissingScriptがなければ検出しない()
+        {
+            _instance = new GameObject("Avatar");
+
+            Assert.IsEmpty(_check.Execute(_instance).ToList());
+        }
+
+        [Test]
+        public void MissingScriptを検出し修正で削除できる()
+        {
+            _instance = CreateInstanceWithMissingScript();
+
+            var results = _check.Execute(_instance).ToList();
+
+            Assert.AreEqual(1, results.Count);
+            Assert.AreEqual(Severity.Error, results[0].Severity);
+            Assert.IsTrue(results[0].HasFix);
+
+            results[0].FixAction();
+
+            Assert.IsEmpty(_check.Execute(_instance).ToList(), "修正後も Missing Script が残っている");
+            Assert.AreEqual(1, FixHistoryStore.Count, "修正履歴が記録されていない");
+        }
+
+        /// <summary>
+        /// Missing Script はコードから直接は作れないため、DummyBehaviour 付きの Prefab を保存してから
+        /// .prefab テキスト内のスクリプト GUID を存在しない GUID に書き換えて生成する。
+        /// </summary>
+        private static GameObject CreateInstanceWithMissingScript()
+        {
+            var go = new GameObject("MissingScriptFixture");
+            go.AddComponent<DummyBehaviour>();
+            PrefabUtility.SaveAsPrefabAsset(go, PrefabPath);
+            Object.DestroyImmediate(go);
+
+            var text = File.ReadAllText(PrefabPath);
+            text = Regex.Replace(text, @"guid: [0-9a-f]{32}", "guid: deadbeefdeadbeefdeadbeefdeadbeef");
+            File.WriteAllText(PrefabPath, text);
+            AssetDatabase.ImportAsset(PrefabPath);
+
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(PrefabPath);
+            var instance = (GameObject)PrefabUtility.InstantiatePrefab(prefab);
+            // Prefab インスタンスのままだとコンポーネント削除が制限されるため、修正テスト用に unpack する
+            PrefabUtility.UnpackPrefabInstance(instance, PrefabUnpackMode.Completely, InteractionMode.AutomatedAction);
+            return instance;
+        }
+    }
+}

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/MissingScriptCheckTests.cs.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/MissingScriptCheckTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c49e4d0e1b730d6de131ecfef940f2fe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/MissingShaderCheckTests.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/MissingShaderCheckTests.cs
@@ -1,0 +1,67 @@
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using AvatarOmamori.Editor;
+using AvatarOmamori.Editor.Checks;
+
+namespace AvatarOmamori.Tests.Editor
+{
+    public class MissingShaderCheckTests
+    {
+        private GameObject _root;
+        private Material _material;
+        private readonly MissingShaderCheck _check = new MissingShaderCheck();
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new GameObject("Avatar");
+            var body = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            body.name = "Body";
+            body.transform.SetParent(_root.transform);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_material != null) Object.DestroyImmediate(_material);
+            if (_root != null) Object.DestroyImmediate(_root);
+        }
+
+        private Renderer BodyRenderer => _root.GetComponentInChildren<Renderer>();
+
+        [Test]
+        public void 正常なマテリアルなら検出しない()
+        {
+            _material = new Material(Shader.Find("Standard"));
+            BodyRenderer.sharedMaterials = new[] { _material };
+
+            Assert.IsEmpty(_check.Execute(_root).ToList());
+        }
+
+        [Test]
+        public void nullマテリアルスロットを検出する()
+        {
+            BodyRenderer.sharedMaterials = new Material[] { null };
+
+            var results = _check.Execute(_root).ToList();
+
+            Assert.AreEqual(1, results.Count);
+            Assert.AreEqual(Severity.Warning, results[0].Severity);
+            Assert.That(results[0].Message, Does.Contain("[0]"));
+        }
+
+        [Test]
+        public void エラーシェーダーのマテリアルを検出する()
+        {
+            _material = new Material(Shader.Find("Hidden/InternalErrorShader"));
+            BodyRenderer.sharedMaterials = new[] { _material };
+
+            var results = _check.Execute(_root).ToList();
+
+            Assert.AreEqual(1, results.Count);
+            Assert.AreEqual(Severity.Warning, results[0].Severity);
+            Assert.That(results[0].Message, Does.Contain("Hidden/InternalErrorShader"));
+        }
+    }
+}

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/MissingShaderCheckTests.cs.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/MissingShaderCheckTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 02d4671b78da23c896f76538964d72ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/SanitizeKeyTests.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/SanitizeKeyTests.cs
@@ -1,0 +1,52 @@
+using NUnit.Framework;
+using AvatarOmamori.Editor;
+
+namespace AvatarOmamori.Tests.Editor
+{
+    /// <summary>
+    /// SanitizeKey は「個人情報（アバター名・パス・日本語など）をキーとして保存しない」という
+    /// README / VPM LP でのユーザーへの約束（DEC-055）を支える最終防波堤。
+    /// この保証が将来の変更で緩まないことをテストで固定する。
+    /// </summary>
+    public class SanitizeKeyTests
+    {
+        [TestCase(null)]
+        [TestCase("")]
+        public void 空のキーはnullになる(string raw)
+        {
+            Assert.IsNull(UsageStatsRecorder.SanitizeKey(raw));
+        }
+
+        [TestCase("MissingScriptCheck")]
+        [TestCase("_under_score_09")]
+        [TestCase("ABCxyz012")]
+        public void ASCII識別子はそのまま通る(string raw)
+        {
+            Assert.AreEqual(raw, UsageStatsRecorder.SanitizeKey(raw));
+        }
+
+        [Test]
+        public void 上限64文字ちょうどは通る()
+        {
+            var key = new string('a', 64);
+
+            Assert.AreEqual(key, UsageStatsRecorder.SanitizeKey(key));
+        }
+
+        [Test]
+        public void 上限を超える65文字はnullになる()
+        {
+            Assert.IsNull(UsageStatsRecorder.SanitizeKey(new string('a', 65)));
+        }
+
+        [TestCase("アバター名")]
+        [TestCase("Assets/Foo.prefab")]
+        [TestCase("has space")]
+        [TestCase("has-hyphen")]
+        [TestCase("emoji😀mixed")]
+        public void 日本語やパスや記号を含むキーはnullになる(string raw)
+        {
+            Assert.IsNull(UsageStatsRecorder.SanitizeKey(raw));
+        }
+    }
+}

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/SanitizeKeyTests.cs.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/SanitizeKeyTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cdb95641b3a9823e957d0a9dc3b7832e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/UsageStatsRecorderTests.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/UsageStatsRecorderTests.cs
@@ -1,0 +1,146 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using AvatarOmamori.Editor;
+
+namespace AvatarOmamori.Tests.Editor
+{
+    public class UsageStatsRecorderTests
+    {
+        private string _dir;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _dir = UsageStatsTestUtil.BeginOverride();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            UsageStatsTestUtil.EndOverride(_dir);
+        }
+
+        [Test]
+        public void RecordCheckRun_実行回数と種別ごとの検出件数が加算される()
+        {
+            UsageStatsRecorder.RecordCheckRun(new Dictionary<string, int>
+            {
+                { "MissingScriptCheck", 3 },
+                { "DescriptorDuplicateCheck", 1 },
+            });
+            UsageStatsRecorder.RecordCheckRun(new Dictionary<string, int>
+            {
+                { "MissingScriptCheck", 2 },
+            });
+
+            var stats = UsageStatsRecorder.GetSnapshot();
+            Assert.AreEqual(2, stats.CheckRunCount);
+            Assert.AreEqual(5, stats.DetectionCounts["MissingScriptCheck"]);
+            Assert.AreEqual(1, stats.DetectionCounts["DescriptorDuplicateCheck"]);
+        }
+
+        [Test]
+        public void RecordCheckRun_0件以下のエントリと不正キーは記録されない()
+        {
+            UsageStatsRecorder.RecordCheckRun(new Dictionary<string, int>
+            {
+                { "ZeroCheck", 0 },
+                { "NegativeCheck", -1 },
+                { "アバター名", 5 },
+            });
+
+            var stats = UsageStatsRecorder.GetSnapshot();
+            Assert.AreEqual(1, stats.CheckRunCount);
+            Assert.IsEmpty(stats.DetectionCounts);
+        }
+
+        [Test]
+        public void RecordFix_種別ごとの修正回数が加算される()
+        {
+            UsageStatsRecorder.RecordFix("AnimatorLayerWeightCheck");
+            UsageStatsRecorder.RecordFix("AnimatorLayerWeightCheck");
+
+            var stats = UsageStatsRecorder.GetSnapshot();
+            Assert.AreEqual(2, stats.FixRunCounts["AnimatorLayerWeightCheck"]);
+        }
+
+        [Test]
+        public void OptOut中は何も記録されない()
+        {
+            UsageStatsRecorder.SetOptOut(true);
+
+            UsageStatsRecorder.RecordCheckRun(new Dictionary<string, int> { { "MissingScriptCheck", 1 } });
+            UsageStatsRecorder.RecordFix("MissingScriptCheck");
+
+            var stats = UsageStatsRecorder.GetSnapshot();
+            Assert.IsTrue(stats.OptOut);
+            Assert.AreEqual(0, stats.CheckRunCount);
+            Assert.IsEmpty(stats.DetectionCounts);
+            Assert.IsEmpty(stats.FixRunCounts);
+        }
+
+        [Test]
+        public void 記録される日付は年月日のみの形式になる()
+        {
+            UsageStatsRecorder.RecordCheckRun(new Dictionary<string, int>());
+
+            var stats = UsageStatsRecorder.GetSnapshot();
+            var dateOnly = new Regex(@"^\d{4}-\d{2}-\d{2}$");
+            Assert.IsTrue(dateOnly.IsMatch(stats.FirstRun), $"FirstRun が年月日のみの形式でない: {stats.FirstRun}");
+            Assert.IsTrue(dateOnly.IsMatch(stats.LastRun), $"LastRun が年月日のみの形式でない: {stats.LastRun}");
+        }
+
+        [Test]
+        public void 保存済みファイルの不正キーは読み込み時に捨てられる()
+        {
+            var json = "{\n" +
+                       "  \"schema_version\": 1,\n" +
+                       "  \"tool_version\": \"0.6.0\",\n" +
+                       "  \"first_run\": \"2026-07-01\",\n" +
+                       "  \"last_run\": \"2026-07-01\",\n" +
+                       "  \"opt_out\": false,\n" +
+                       "  \"check_run_count\": 3,\n" +
+                       "  \"detection_counts\": [\n" +
+                       "    { \"key\": \"アバター名\", \"count\": 5 },\n" +
+                       "    { \"key\": \"MissingScriptCheck\", \"count\": 2 }\n" +
+                       "  ],\n" +
+                       "  \"fix_run_counts\": [],\n" +
+                       "  \"last_exported_at\": \"\"\n" +
+                       "}\n";
+            File.WriteAllText(Path.Combine(_dir, "usage-stats.json"), json);
+            UsageStatsRecorder.ResetForTests(); // キャッシュを捨てて上のファイルを読み直させる
+
+            var stats = UsageStatsRecorder.GetSnapshot();
+            Assert.AreEqual(3, stats.CheckRunCount);
+            Assert.IsFalse(stats.DetectionCounts.ContainsKey("アバター名"), "不正キーが読み込み時に除去されていない");
+            Assert.AreEqual(2, stats.DetectionCounts["MissingScriptCheck"]);
+        }
+
+        [Test]
+        public void ClearStats_カウントは消えるがOptOut設定は保持される()
+        {
+            UsageStatsRecorder.SetOptOut(true);
+
+            UsageStatsRecorder.ClearStats();
+
+            var stats = UsageStatsRecorder.GetSnapshot();
+            Assert.IsTrue(stats.OptOut);
+            Assert.AreEqual(0, stats.CheckRunCount);
+            Assert.IsEmpty(stats.DetectionCounts);
+        }
+
+        [Test]
+        public void 記録はディスクに永続化されキャッシュ破棄後も読める()
+        {
+            UsageStatsRecorder.RecordCheckRun(new Dictionary<string, int> { { "MissingScriptCheck", 1 } });
+
+            UsageStatsRecorder.ResetForTests();
+
+            var stats = UsageStatsRecorder.GetSnapshot();
+            Assert.AreEqual(1, stats.CheckRunCount);
+            Assert.AreEqual(1, stats.DetectionCounts["MissingScriptCheck"]);
+        }
+    }
+}

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/UsageStatsRecorderTests.cs.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/UsageStatsRecorderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 264467d89e7d50c85e48af7015f39518
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/UsageStatsTestUtil.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/UsageStatsTestUtil.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using AvatarOmamori.Editor;
+
+namespace AvatarOmamori.Tests.Editor
+{
+    /// <summary>
+    /// 利用統計の保存先を一時フォルダへ退避させるテスト用ヘルパー。
+    /// 実プロジェクトの Library/ を汚さず、テスト間の状態も分離する。
+    /// </summary>
+    internal static class UsageStatsTestUtil
+    {
+        /// <summary>一時フォルダを作って保存先を差し替え、そのパスを返す。</summary>
+        public static string BeginOverride()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "omamori-tests-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            UsageStatsRecorder.ResetForTests();
+            UsageStatsRecorder.StatsDirOverrideForTests = dir;
+            return dir;
+        }
+
+        /// <summary>保存先の差し替えを解除し、一時フォルダを削除する。</summary>
+        public static void EndOverride(string dir)
+        {
+            UsageStatsRecorder.StatsDirOverrideForTests = null;
+            UsageStatsRecorder.ResetForTests();
+            if (!string.IsNullOrEmpty(dir) && Directory.Exists(dir))
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+    }
+}

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/UsageStatsTestUtil.cs.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/UsageStatsTestUtil.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4162b0fc072469574b54e13238b5a358
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/UsageStatsTests.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/UsageStatsTests.cs
@@ -1,0 +1,23 @@
+using NUnit.Framework;
+using AvatarOmamori.Editor;
+
+namespace AvatarOmamori.Tests.Editor
+{
+    public class UsageStatsTests
+    {
+        [Test]
+        public void Clone_ディープコピーなので元への変更がコピーに影響しない()
+        {
+            var original = new UsageStats { CheckRunCount = 1 };
+            original.DetectionCounts["MissingScriptCheck"] = 2;
+
+            var clone = original.Clone();
+            original.DetectionCounts["MissingScriptCheck"] = 99;
+            original.FixRunCounts["AnimatorLayerWeightCheck"] = 1;
+
+            Assert.AreEqual(1, clone.CheckRunCount);
+            Assert.AreEqual(2, clone.DetectionCounts["MissingScriptCheck"]);
+            Assert.IsFalse(clone.FixRunCounts.ContainsKey("AnimatorLayerWeightCheck"));
+        }
+    }
+}

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/UsageStatsTests.cs.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/UsageStatsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7298a35142a8f3c117f70f833949ce9d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/com.tsukumodo.avatar-omamori.tests.editor.asmdef
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/com.tsukumodo.avatar-omamori.tests.editor.asmdef
@@ -1,0 +1,25 @@
+{
+    "name": "com.tsukumodo.avatar-omamori.tests.editor",
+    "rootNamespace": "AvatarOmamori.Tests.Editor",
+    "references": [
+        "com.tsukumodo.avatar-omamori.editor",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "VRC.SDK3A"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/com.tsukumodo.avatar-omamori.tests.editor.asmdef
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/com.tsukumodo.avatar-omamori.tests.editor.asmdef
@@ -3,6 +3,7 @@
     "rootNamespace": "AvatarOmamori.Tests.Editor",
     "references": [
         "com.tsukumodo.avatar-omamori.editor",
+        "com.tsukumodo.avatar-omamori.tests.runtime",
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
         "VRC.SDK3A"
@@ -12,7 +13,7 @@
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": true,
+    "overrideReferences": false,
     "precompiledReferences": [
         "nunit.framework.dll"
     ],

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/com.tsukumodo.avatar-omamori.tests.editor.asmdef.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/com.tsukumodo.avatar-omamori.tests.editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9fe9ecdffe5384ddc92eb333ccc8532c
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Runtime.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7c3f1a9e2b6d4058a1c2e3f405162738
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Runtime/DummyBehaviour.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Runtime/DummyBehaviour.cs
@@ -5,6 +5,8 @@ namespace AvatarOmamori.Tests.Editor
     /// <summary>
     /// MissingScriptCheck のテストフィクスチャ生成用の空 MonoBehaviour。
     /// Prefab に保存した後、スクリプト GUID を書き換えて Missing Script 化する。
+    /// GameObject に AddComponent するため、Editor アセンブリではなくランタイム
+    /// アセンブリ（このフォルダ）に置く必要がある。
     /// </summary>
     public sealed class DummyBehaviour : MonoBehaviour
     {

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Runtime/DummyBehaviour.cs.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Runtime/DummyBehaviour.cs.meta
@@ -6,6 +6,6 @@ MonoImporter:
   defaultReferences: []
   executionOrder: 0
   icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Runtime/com.tsukumodo.avatar-omamori.tests.runtime.asmdef
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Runtime/com.tsukumodo.avatar-omamori.tests.runtime.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "com.tsukumodo.avatar-omamori.tests.runtime",
+    "rootNamespace": "AvatarOmamori.Tests",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Runtime/com.tsukumodo.avatar-omamori.tests.runtime.asmdef.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Runtime/com.tsukumodo.avatar-omamori.tests.runtime.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5e9d8c7b6a5049382716f5e4d3c2b1a0
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -39,5 +39,8 @@
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
     "com.unity.modules.xr": "1.0.0"
-  }
+  },
+  "testables": [
+    "com.tsukumodo.avatar-omamori"
+  ]
 }


### PR DESCRIPTION
## 概要

これまでゼロだった自動テストを導入します。3コミット構成で、それぞれ issue に対応しています。

Closes #20
Closes #21
Closes #22

## 変更内容

### 1. テスト基盤（#20）
- テスト用 asmdef `com.tsukumodo.avatar-omamori.tests.editor` を `Tests/Editor/` に追加
- `Packages/manifest.json` に `testables` を登録（Test Runner にパッケージ内テストを表示させるため）
- `Editor/AssemblyInfo.cs` の `InternalsVisibleTo` で internal メンバー（`FixHistoryStore` / `SanitizeKey` 等）をテスト可能に
- スモークテスト2本（`HierarchyPathUtil` のパス生成 / `CheckRunner` の9チェック自動発見）

### 2. 利用統計のプライバシー保証テスト（#21）
- `UsageStatsRecorder.SanitizeKey` を `private` → `internal` に変更
- テスト用フック `StatsDirOverrideForTests` / `ResetForTests()` を追加（**記録の挙動自体は不変**。テストが実プロジェクトの `Library/` を汚さないための口）
- テスト: SanitizeKey の許可/拒否（日本語・パス・記号・64/65文字境界）、opt-out 中の無記録、日付が年月日のみであること、読み込み時の不正キー除去、永続化、`UsageStats.Clone` のディープコピー

### 3. SDK/Unity 系チェック6種のテスト（#22）
- `CheckRunner.RunAll` にチェック群を注入できる internal オーバーロードを追加（公開 API の挙動は不変）。フェイクチェックで例外分離・`IsAvailable` スキップを検証
- 6チェックの検出境界と FixAction をテスト:
  - Descriptor 重複（サマリー+重複箇所の2件、SkipConfirm）
  - Missing Script（**フィクスチャは実行時生成**: Prefab 保存後にスクリプト GUID を無効値へ書き換え。修正で削除→再検出ゼロ+修正履歴の記録まで確認）
  - シェーダー未検出（null スロット / InternalErrorShader / 正常系）
  - Expression Parameter（Menu あり Parameters なし / 空名エントリの添字 / 正常系）
  - 同期パラメータ上限（256bit ちょうど / 264bit 超過 / 非同期除外 / Bool=1bit）
  - FX レイヤー Weight（検出+修正で 0→1 / ベースレイヤー除外 / isDefault 除外）

## テスト

✅ Unity 2022.3.22f1 の Test Runner（EditMode）で**全テスト緑を確認済み**（実機確認時に見つかった asmdef の参照設定と `DummyBehaviour` の配置は d584f81 で修正済み — テスト asmdef を `overrideReferences: false` に統一、`DummyBehaviour` は `UNITY_INCLUDE_TESTS` 制約付きの `Tests/Runtime` アセンブリへ移動）。#24（CI 導入）が入れば以後は自動化されます。

MA 系チェック3種のテスト（#23）は開発プロジェクトへの Modular Avatar 導入を伴うため、この PR には含めていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017chzgTtksVG9Zs9oFuwMqS