### PR TITLE
chore: AGENTS.md を .gitignore に追加（ローカル専用に統一）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ Assets/PackageMakerWindowData.asset*
 
 # Internal project documents
 CLAUDE.md
+AGENTS.md
 
 # BOOTH / distribution resources
 Resources/


### PR DESCRIPTION
## 概要

`AGENTS.md` を `.gitignore` に追加します。

## 背景

- このリポジトリは、エージェント向けの指示ファイルを**ローカル専用**にする方針です（`CLAUDE.md` は既に gitignore 済み）。
- `AGENTS.md`（Codex 等の AGENTS.md 規約用）も同じ扱いに揃えます。
- ローカルの `AGENTS.md` は、`CLAUDE.md` の全文コピーになっていたものを、**`CLAUDE.md` を指す薄いポインタ**へ整理済みです（内容の二重管理・ドリフトを防止）。バージョン番号などが既に古くなっていた問題も解消。

## 変更内容

- `.gitignore` に `AGENTS.md` を1行追加（`CLAUDE.md` の直下）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
