### PR TITLE
chore: 挙動を変えないリファクタ3件 (#26 / #34 / #25)

### DIFF
--- a/Packages/com.tsukumodo.avatar-omamori/Editor/AvatarOmamoriWindow.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/AvatarOmamoriWindow.cs
@@ -90,6 +90,40 @@ namespace AvatarOmamori.Editor
                 DrawFirstRunNotice();
             }
 
+            DrawAvatarRootField();
+
+            EditorGUILayout.Space(4);
+
+            DrawCheckButton();
+
+            if (_results == null)
+                return;
+
+            EditorGUILayout.Space(4);
+
+            DrawSummary();
+
+            // ランクは1行だけスクロールの外に出す。詳細は結果の下（DEC-073）
+            DrawPerformanceSummaryLine();
+            EditorGUILayout.Space(2);
+
+            DrawResultsScrollView();
+
+            // GL 描画とフォントアトラスの状態が安定している Repaint イベント中に、カードの書き出しを実行する。
+            // 空文字も弾く（RequestCardSave 側のキャンセル判定と条件を揃える）。
+            if (Event.current.type == EventType.Repaint && !string.IsNullOrEmpty(_pendingCardSavePath))
+            {
+                var path = _pendingCardSavePath;
+                _pendingCardSavePath = null;
+                ExportCard(path);
+            }
+        }
+
+        /// <summary>
+        /// アバタールートの ObjectField を描画し、参照が変わったら自動でチェックを走らせる。
+        /// </summary>
+        private void DrawAvatarRootField()
+        {
             var newAvatarRoot = (GameObject)EditorGUILayout.ObjectField(
                 "アバタールート", _avatarRoot, typeof(GameObject), true);
             if (newAvatarRoot != _avatarRoot)
@@ -108,9 +142,13 @@ namespace AvatarOmamori.Editor
                     _performanceReport = null;
                 }
             }
+        }
 
-            EditorGUILayout.Space(4);
-
+        /// <summary>
+        /// 「チェック実行」ボタンを描画する。アバター未指定のときは押せない。
+        /// </summary>
+        private void DrawCheckButton()
+        {
             using (new EditorGUI.DisabledScope(_avatarRoot == null))
             {
                 if (GUILayout.Button("チェック実行", GUILayout.Height(30)))
@@ -118,12 +156,13 @@ namespace AvatarOmamori.Editor
                     RunChecks();
                 }
             }
+        }
 
-            if (_results == null)
-                return;
-
-            EditorGUILayout.Space(4);
-
+        /// <summary>
+        /// 件数サマリーと「カードを保存」ボタンの行を描画する。
+        /// </summary>
+        private void DrawSummary()
+        {
             // サマリー。内訳行は「1つの問題を説明する補助行」なので件数に数えない（CountPrimary）
             var summary = $"結果: {CountPrimary(_errors)} Error / {CountPrimary(_warnings)} Warning / {CountPrimary(_infos)} Info";
             var summaryStyle = GetSummaryStyle();
@@ -145,11 +184,13 @@ namespace AvatarOmamori.Editor
                 RequestCardSave();
             }
             EditorGUILayout.EndHorizontal();
+        }
 
-            // ランクは1行だけスクロールの外に出す。詳細は結果の下（DEC-073）
-            DrawPerformanceSummaryLine();
-            EditorGUILayout.Space(2);
-
+        /// <summary>
+        /// Severity グループ・パフォーマンス詳細・修正履歴をまとめたスクロール領域を描画する。
+        /// </summary>
+        private void DrawResultsScrollView()
+        {
             _scrollPos = EditorGUILayout.BeginScrollView(_scrollPos);
 
             // 表示条件は CountPrimary ではなく生の Count で見る。
@@ -178,15 +219,6 @@ namespace AvatarOmamori.Editor
             }
 
             EditorGUILayout.EndScrollView();
-
-            // GL 描画とフォントアトラスの状態が安定している Repaint イベント中に、カードの書き出しを実行する。
-            // 空文字も弾く（RequestCardSave 側のキャンセル判定と条件を揃える）。
-            if (Event.current.type == EventType.Repaint && !string.IsNullOrEmpty(_pendingCardSavePath))
-            {
-                var path = _pendingCardSavePath;
-                _pendingCardSavePath = null;
-                ExportCard(path);
-            }
         }
 
         /// <summary>
@@ -341,7 +373,16 @@ namespace AvatarOmamori.Editor
             return _ratingStyle;
         }
 
-        private GUIStyle GetFoldoutStyle()
+        /// <summary>
+        /// Foldout 見出しのスタイルを、<paramref name="color"/> を設定した状態で返す。
+        ///
+        /// <para>
+        /// 色は必ず引数で受け取る。以前は共有インスタンスを返すだけで、呼び出し元が描画直前に
+        /// textColor を書き換える約束になっていたため、設定を忘れた呼び出し元が直前の Foldout の色を
+        /// 引き継いでしまう暗黙依存があった（#34）。引数化して構造的に起こらないようにしている。
+        /// </para>
+        /// </summary>
+        private GUIStyle GetFoldoutStyle(Color color)
         {
             if (_foldoutStyle == null)
             {
@@ -350,116 +391,154 @@ namespace AvatarOmamori.Editor
                     fontStyle = FontStyle.Bold
                 };
             }
+
+            _foldoutStyle.normal.textColor = color;
+            _foldoutStyle.onNormal.textColor = color;
             return _foldoutStyle;
         }
 
         private void DrawSeverityGroup(string label, List<CheckResult> items, ref bool foldout, Color color)
         {
-            var style = GetFoldoutStyle();
-            style.normal.textColor = color;
-            style.onNormal.textColor = color;
-
-            foldout = EditorGUILayout.Foldout(foldout, $"{label} ({CountPrimary(items)})", true, style);
+            foldout = EditorGUILayout.Foldout(
+                foldout, $"{label} ({CountPrimary(items)})", true, GetFoldoutStyle(color));
             if (!foldout)
                 return;
 
             EditorGUI.indentLevel++;
             foreach (var result in items)
             {
-                // 内訳行は1段字下げして、直前のサマリー行にぶら下がっていることを見た目で示す
-                if (result.IsDetail)
-                {
-                    EditorGUILayout.BeginHorizontal();
-                    GUILayout.Space(DetailIndentWidth);
-                }
-
-                EditorGUILayout.BeginVertical("box");
-                EditorGUILayout.BeginHorizontal();
-
-                // Severity アイコン。内訳行では出さず（同じ赤アイコンが並ぶと問題が複数あるように見えるため）、
-                // 代わりに同じ幅だけ空けて本文の開始位置をサマリー行と揃える
-                if (result.IsDetail)
-                {
-                    GUILayout.Space(SeverityIconWidth);
-                }
-                else
-                {
-                    var iconContent = GetSeverityIcon(result.Severity);
-                    if (iconContent != null)
-                    {
-                        GUILayout.Label(iconContent, GUILayout.Width(SeverityIconWidth), GUILayout.Height(20));
-                    }
-                }
-
-                EditorGUILayout.LabelField(result.Message, EditorStyles.wordWrappedLabel);
-
-                if (result.TargetObject != null)
-                {
-                    if (GUILayout.Button("選択", GUILayout.Width(40)))
-                    {
-                        EditorGUIUtility.PingObject(result.TargetObject);
-                        Selection.activeObject = result.TargetObject;
-                    }
-                }
-
-                if (result.HasFix)
-                {
-                    var fixLabel = result.FixLabel ?? "修正";
-                    // デフォルト「修正」のときは「選択」ボタンと幅を揃え、カスタムラベル指定時のみ内容に合わせて広げる
-                    var fixWidth = result.FixLabel == null
-                        ? 40f
-                        : GUI.skin.button.CalcSize(new GUIContent(fixLabel)).x + 8f;
-                    if (GUILayout.Button(fixLabel, GUILayout.Width(fixWidth)))
-                    {
-                        var capturedResult = result;
-                        if (capturedResult.SkipConfirm)
-                        {
-                            // FixAction 側で独自ウィンドウを出す項目（例: Descriptor 重複の選択ウィンドウ）。
-                            // 事前確認は出さず、再チェックも FixAction 側が完了時に RefreshResults() を呼ぶ責任を持つ。
-                            ExecuteFix(capturedResult, refreshAfter: false);
-                        }
-                        else
-                        {
-                            var msg = capturedResult.FixConfirmMessage ?? "この問題を自動修正しますか？\nUndo（Ctrl+Z）で元に戻せます。";
-                            OmamoriConfirmWindow.Show(
-                                title: "おまもり — 自動修正",
-                                message: msg,
-                                okLabel: "修正する",
-                                cancelLabel: "キャンセル",
-                                onOk: () => ExecuteFix(capturedResult, refreshAfter: true));
-                        }
-                    }
-                }
-
-                EditorGUILayout.EndHorizontal();
-
-                if (!string.IsNullOrEmpty(result.ValueLabel) &&
-                    (result.BeforeValue != null || result.AfterValue != null))
-                {
-                    EditorGUILayout.BeginHorizontal();
-                    // アイコン幅(20)+α + 上位の indentLevel 分(15px×段数) を加算してメッセージ本文の下に揃える
-                    GUILayout.Space(24f + EditorGUI.indentLevel * 15f);
-                    OmamoriPopupStyles.DrawValueSnapshot(
-                        result.ValueLabel, result.BeforeValue, result.AfterValue);
-                    EditorGUILayout.EndHorizontal();
-                }
-
-                EditorGUILayout.EndVertical();
-
-                if (result.IsDetail)
-                {
-                    EditorGUILayout.EndHorizontal();
-                }
-
-                EditorGUILayout.Space(2);
+                DrawResultCard(result);
             }
             EditorGUI.indentLevel--;
+        }
+
+        /// <summary>
+        /// 結果1件分のカードを描画する。
+        ///
+        /// <para>
+        /// 字下げ量の計算が <see cref="EditorGUI.indentLevel"/> に依存しているため、
+        /// 必ず <see cref="DrawSeverityGroup"/> の indentLevel++ / -- の内側から呼ぶこと。
+        /// </para>
+        /// </summary>
+        private void DrawResultCard(CheckResult result)
+        {
+            // 内訳行は1段字下げして、直前のサマリー行にぶら下がっていることを見た目で示す
+            if (result.IsDetail)
+            {
+                EditorGUILayout.BeginHorizontal();
+                GUILayout.Space(DetailIndentWidth);
+            }
+
+            EditorGUILayout.BeginVertical("box");
+            EditorGUILayout.BeginHorizontal();
+
+            // Severity アイコン。内訳行では出さず（同じ赤アイコンが並ぶと問題が複数あるように見えるため）、
+            // 代わりに同じ幅だけ空けて本文の開始位置をサマリー行と揃える
+            if (result.IsDetail)
+            {
+                GUILayout.Space(SeverityIconWidth);
+            }
+            else
+            {
+                var iconContent = GetSeverityIcon(result.Severity);
+                if (iconContent != null)
+                {
+                    GUILayout.Label(iconContent, GUILayout.Width(SeverityIconWidth), GUILayout.Height(20));
+                }
+            }
+
+            EditorGUILayout.LabelField(result.Message, EditorStyles.wordWrappedLabel);
+
+            if (result.TargetObject != null)
+            {
+                if (GUILayout.Button("選択", GUILayout.Width(40)))
+                {
+                    EditorGUIUtility.PingObject(result.TargetObject);
+                    Selection.activeObject = result.TargetObject;
+                }
+            }
+
+            DrawFixButton(result);
+
+            EditorGUILayout.EndHorizontal();
+
+            if (!string.IsNullOrEmpty(result.ValueLabel) &&
+                (result.BeforeValue != null || result.AfterValue != null))
+            {
+                // アイコン幅(20)+α の分だけ右にずらしてメッセージ本文の下に揃える
+                DrawValueSnapshotRow(result.ValueLabel, result.BeforeValue, result.AfterValue, 24f);
+            }
+
+            EditorGUILayout.EndVertical();
+
+            if (result.IsDetail)
+            {
+                EditorGUILayout.EndHorizontal();
+            }
+
+            EditorGUILayout.Space(2);
+        }
+
+        /// <summary>
+        /// 結果カードの「修正」ボタンを描画する。
+        /// <see cref="CheckResult.SkipConfirm"/> の項目は FixAction 側が独自 UI と再チェックの責任を持つため、
+        /// 事前確認ウィンドウを出さずに実行する。
+        /// </summary>
+        private void DrawFixButton(CheckResult result)
+        {
+            if (result.HasFix)
+            {
+                var fixLabel = result.FixLabel ?? "修正";
+                // デフォルト「修正」のときは「選択」ボタンと幅を揃え、カスタムラベル指定時のみ内容に合わせて広げる
+                var fixWidth = result.FixLabel == null
+                    ? 40f
+                    : GUI.skin.button.CalcSize(new GUIContent(fixLabel)).x + 8f;
+                if (GUILayout.Button(fixLabel, GUILayout.Width(fixWidth)))
+                {
+                    var capturedResult = result;
+                    if (capturedResult.SkipConfirm)
+                    {
+                        // FixAction 側で独自ウィンドウを出す項目（例: Descriptor 重複の選択ウィンドウ）。
+                        // 事前確認は出さず、再チェックも FixAction 側が完了時に RefreshResults() を呼ぶ責任を持つ。
+                        ExecuteFix(capturedResult, refreshAfter: false);
+                    }
+                    else
+                    {
+                        var msg = capturedResult.FixConfirmMessage ?? "この問題を自動修正しますか？\nUndo（Ctrl+Z）で元に戻せます。";
+                        OmamoriConfirmWindow.Show(
+                            title: "おまもり — 自動修正",
+                            message: msg,
+                            okLabel: "修正する",
+                            cancelLabel: "キャンセル",
+                            onOk: () => ExecuteFix(capturedResult, refreshAfter: true));
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Before / After の値を1行で描画する。
+        ///
+        /// <para>
+        /// <paramref name="leftOffset"/> は呼び出し元ごとに異なる（結果カードは Severity アイコン幅を
+        /// 考慮して 24、修正履歴はヘッダ行に合わせて 4）。ここを揃えると見た目が変わるので引数で受け取る。
+        /// </para>
+        /// </summary>
+        private static void DrawValueSnapshotRow(string label, string before, string after, float leftOffset)
+        {
+            EditorGUILayout.BeginHorizontal();
+            GUILayout.Space(leftOffset + EditorGUI.indentLevel * 15f);
+            OmamoriPopupStyles.DrawValueSnapshot(label, before, after);
+            EditorGUILayout.EndHorizontal();
         }
 
         // ───────────────────────────── パフォーマンス表示（v0.9.0 / DEC-070） ─────────────────────────────
 
         /// <summary>ブランドの金色。パフォーマンスセクションの見出しに使い、Severity の色と混同させない。</summary>
         private static readonly Color AccentGold = new Color(0.784f, 0.659f, 0.486f);
+
+        /// <summary>修正履歴の見出し色。Severity・パフォーマンスのどちらとも混同させないための灰色。</summary>
+        private static readonly Color HistoryGray = new Color(0.6f, 0.6f, 0.6f);
 
         /// <summary>
         /// 総合ランクだけを1行で表示する（DEC-073）。
@@ -497,11 +576,8 @@ namespace AvatarOmamori.Editor
         {
             if (_performanceReport == null) return;
 
-            var foldoutStyle = GetFoldoutStyle();
-            foldoutStyle.normal.textColor = AccentGold;
-            foldoutStyle.onNormal.textColor = AccentGold;
-
-            _foldPerformance = EditorGUILayout.Foldout(_foldPerformance, "パフォーマンス", true, foldoutStyle);
+            _foldPerformance = EditorGUILayout.Foldout(
+                _foldPerformance, "パフォーマンス", true, GetFoldoutStyle(AccentGold));
             if (!_foldPerformance) return;
 
             if (!_performanceReport.IsValid)
@@ -747,13 +823,9 @@ namespace AvatarOmamori.Editor
         /// </summary>
         private void DrawFixHistoryGroup()
         {
-            var foldoutStyle = GetFoldoutStyle();
-            foldoutStyle.normal.textColor = new Color(0.6f, 0.6f, 0.6f);
-            foldoutStyle.onNormal.textColor = new Color(0.6f, 0.6f, 0.6f);
-
             EditorGUILayout.BeginHorizontal();
             _foldHistory = EditorGUILayout.Foldout(
-                _foldHistory, $"修正履歴 ({FixHistoryStore.Count})", true, foldoutStyle);
+                _foldHistory, $"修正履歴 ({FixHistoryStore.Count})", true, GetFoldoutStyle(HistoryGray));
             GUILayout.FlexibleSpace();
             if (GUILayout.Button("クリア", GUILayout.Width(60)))
             {
@@ -783,11 +855,7 @@ namespace AvatarOmamori.Editor
                 }
                 EditorGUILayout.EndHorizontal();
 
-                EditorGUILayout.BeginHorizontal();
-                GUILayout.Space(4f + EditorGUI.indentLevel * 15f);
-                OmamoriPopupStyles.DrawValueSnapshot(
-                    entry.ValueLabel, entry.BeforeValue, entry.AfterValue);
-                EditorGUILayout.EndHorizontal();
+                DrawValueSnapshotRow(entry.ValueLabel, entry.BeforeValue, entry.AfterValue, 4f);
 
                 EditorGUILayout.EndVertical();
                 EditorGUILayout.Space(2);

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/Util/MAReflectionHelper.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/Util/MAReflectionHelper.cs
@@ -12,6 +12,7 @@ namespace AvatarOmamori.Editor.Util
     public static class MAReflectionHelper
     {
         private static bool s_initialized;
+        private static bool s_warnedResolveFailure;
         private static Assembly s_maAssembly;
         private static Type s_menuItemType;
         private static Type s_menuInstallerType;
@@ -117,7 +118,7 @@ namespace AvatarOmamori.Editor.Util
 
         /// <summary>
         /// ToggledObject から参照先の GameObject を解決する。
-        /// 優先順位: Get(Component) メソッド → targetObject フィールド
+        /// 解決処理そのものは <see cref="ResolveAvatarObjectReference"/> に委譲する。
         /// </summary>
         public static GameObject ResolveToggledTarget(object toggledObject, Component context)
         {
@@ -128,7 +129,26 @@ namespace AvatarOmamori.Editor.Util
             var avatarObjRef = s_toggledObjectObjectField?.GetValue(toggledObject);
             if (avatarObjRef == null) return null;
 
-            // 方法1: Get(Component) メソッドで解決
+            return ResolveAvatarObjectReference(avatarObjRef, context);
+        }
+
+        /// <summary>
+        /// AvatarObjectReference を解決して GameObject を返す共通メソッド。
+        /// 優先順位: Get(Component) メソッド → targetObject フィールド
+        ///
+        /// <para>
+        /// 「方法1が失敗して方法2で成功」は MA のバージョン差を吸収するための正常系なので警告しない。
+        /// 参照が未設定で素直に null になるケースも正常系（設定済みかどうかの判定は呼び出し元の役目）。
+        /// 両方の経路で解決できず、かつ例外が発生していたときだけ、MA のバージョンに追随できていない
+        /// 可能性としてセッション中1回だけ警告する。
+        /// </para>
+        /// </summary>
+        private static GameObject ResolveAvatarObjectReference(object avatarObjRef, Component context)
+        {
+            if (avatarObjRef == null) return null;
+
+            Exception failure = null;
+
             if (s_avatarObjectReferenceGetMethod != null)
             {
                 try
@@ -137,13 +157,12 @@ namespace AvatarOmamori.Editor.Util
                     if (resolved is GameObject go) return go;
                     if (resolved is Transform t) return t.gameObject;
                 }
-                catch
+                catch (Exception e)
                 {
-                    // フォールバックへ
+                    failure = e; // フォールバックへ
                 }
             }
 
-            // 方法2: targetObject フィールドの直接読み取り
             if (s_targetObjectField != null)
             {
                 try
@@ -151,49 +170,29 @@ namespace AvatarOmamori.Editor.Util
                     var target = s_targetObjectField.GetValue(avatarObjRef) as GameObject;
                     if (target != null) return target;
                 }
-                catch
+                catch (Exception e)
                 {
-                    // 解決不能
+                    failure = e;
                 }
+            }
+
+            if (failure != null)
+            {
+                WarnResolveFailureOnce(failure);
             }
 
             return null;
         }
 
         /// <summary>
-        /// AvatarObjectReference を解決して GameObject を返す共通メソッド。
+        /// 参照解決に失敗したことをセッション中1回だけ警告する。
+        /// 毎回出すと ObjectToggle の項目数だけログが並ぶため、初回のみに絞る。
         /// </summary>
-        private static GameObject ResolveAvatarObjectReference(object avatarObjRef, Component context)
+        private static void WarnResolveFailureOnce(Exception e)
         {
-            if (avatarObjRef == null) return null;
-
-            if (s_avatarObjectReferenceGetMethod != null)
-            {
-                try
-                {
-                    var resolved = s_avatarObjectReferenceGetMethod.Invoke(avatarObjRef, new object[] { context });
-                    if (resolved is GameObject go) return go;
-                    if (resolved is Transform t) return t.gameObject;
-                }
-                catch
-                {
-                    // フォールバックへ
-                }
-            }
-
-            if (s_targetObjectField != null)
-            {
-                try
-                {
-                    return s_targetObjectField.GetValue(avatarObjRef) as GameObject;
-                }
-                catch
-                {
-                    // 解決不能
-                }
-            }
-
-            return null;
+            if (s_warnedResolveFailure) return;
+            s_warnedResolveFailure = true;
+            Debug.LogWarning($"[AvatarOmamori] Modular Avatar の参照解決に失敗しました。MA のバージョンに未対応の可能性があります: {e.Message}");
         }
 
         private static void EnsureInitialized()


### PR DESCRIPTION
## 概要

挙動・見た目を変えないリファクタ3件をまとめています。同系統なのでレビューを1回で済ませる意図で1本の PR にしました。

Closes #26
Closes #34
Closes #25

## ⚠️ マージ順序

**#24 の CI（PR: ci/editmode-tests）が緑になってからマージしてください。** リファクタこそ回帰検出の網が要るため、網を張ってから入れる順序にしています。

## 検証状況

| 項目 | 結果 |
|---|---|
| コンパイル | ✅ エラー・警告ゼロ（Unity 2022.3.22f1） |
| EditMode テスト | ✅ **101 件中 101 件パス / 0 失敗**（1.06 秒） |
| #26 記載の手動 UI 確認 | ⚠️ **未検証**（下記） |

テストは開発プロジェクト（Komano）経由で実行しました。当該プロジェクトは本リポジトリの `Packages/com.tsukumodo.avatar-omamori` を Local package として直接参照しているため、この作業ツリーの内容がそのまま走っています。

**未検証の点**: #26 の完了条件にある手動 UI 確認（Foldout 開閉、選択/修正ボタン、Descriptor 重複の SkipConfirm ルート、修正履歴の Ping・クリア、カード保存）は GUI 操作が必要なため実施できていません。とくに **Foldout 見出しの色**（パフォーマンス=金、修正履歴=灰、Severity=赤/黄/青）は #34 の影響範囲なので、マージ前に目視をお願いします。

## 変更内容

### #34 — Foldout スタイルの暗黙依存を解消

`GetFoldoutStyle()` が共有インスタンスを返し、3箇所が描画直前に `textColor` を書き換える構造でした。4つ目の呼び出し元が色設定を忘れると直前の色を引き継ぐ、という暗黙依存になっていたため、`GetFoldoutStyle(Color color)` に変えて**呼び出し元が色を渡さないとコンパイルが通らない**形にしました。

用途別に3インスタンスへ分ける案は採っていません。IMGUI は即時描画なので単一インスタンスでも見た目は変わらず、引数化だけで #34 の目的（暗黙依存の解消）を満たせるためです。修正履歴の灰色は `HistoryGray` として `AccentGold` と並べて定数化しました。

`GetRatingStyle(bool)` / `GetPerformanceSummaryStyle(bool)` も同じ「共有インスタンスの色を書き換える」パターンですが、#34 に「呼び出し元が1箇所なので優先度は低い」とあるため**今回は対象外**としています。

### #26 — OnGUI の描画メソッド分割

`OnGUI` から `DrawAvatarRootField` / `DrawCheckButton` / `DrawSummary` / `DrawResultsScrollView` を、`DrawSeverityGroup` から `DrawResultCard` / `DrawFixButton` を抽出しました。`OnGUI` 本体は 40 行です。

順序を壊しやすい箇所は維持しています。

- `if (_results == null) return;` の早期 return は `OnGUI` 本体に残す（メソッド内に移すと return の意味が変わる）
- カード書き出しの Repaint 処理は `EndScrollView` の**外**に残す
- `DrawResultCard` は `EditorGUI.indentLevel` に依存するため、`indentLevel++` / `--` の内側からのみ呼ぶ（XML コメントにも明記）

結果カードと修正履歴で重複していた Before/After 行は `DrawValueSnapshotRow(label, before, after, leftOffset)` に統一しました。**左オフセットが結果カード 24、修正履歴 4 と異なる**ため、揃えずに引数で吸収しています。#26 本文は「ほぼ同じコード」と書いていますが、実際にはここに差があります。

### #25 — MA 参照解決の重複解消と警告追加

`ResolveToggledTarget` を `ResolveAvatarObjectReference` への委譲に一本化しました。読み比べたところ2つのメソッドは**完全に等価**でした（#25 本文は「Transform 分岐の有無程度の差」としていますが、実際は両方の「方法1」に Transform 分岐があり、差は「方法2」の null チェックの書き方だけで戻り値の意味は同一）。

空 `catch` には警告を追加しましたが、**両方の経路が失敗し、かつ例外が発生したときだけ**セッション中1回だけ出す形にしています。「方法1が失敗して方法2で成功」は MA のバージョン差を吸収する正常系であり、また参照が未設定で素直に null になるケースも正常系（設定済みか判定するのが呼び出し元の役目）なので、そこで警告するとログがスパムになるためです。

## レビュー時の注意

`AvatarOmamoriWindow.cs` の差分は行の移動が主体です。抽出したブロックは機械的に切り出して字下げのみ調整しており、本文は変更していません。#26 に書かれている行番号は Issue 作成時点（372行）のもので、現在（約900行）とは対応しません。
