### PR TITLE
feat: 非対応コンポーネント検出の昇格・利用統計の1往復統合・内訳グループ表示の修正（#36 / #35 / DEC-070）

### DIFF
--- a/Packages/com.tsukumodo.avatar-omamori/Editor/AvatarOmamoriWindow.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/AvatarOmamoriWindow.cs
@@ -614,7 +614,10 @@ namespace AvatarOmamori.Editor
             IReadOnlyList<QuestIncompatibility> incompatibilities = null)
         {
             var hasRating = platform != null && platform.IsValid;
-            var hasIncompatibilities = incompatibilities != null && incompatibilities.Count > 0;
+            // AllPlatforms スコープの項目は v0.10.0 で UnsupportedComponentCheck へ移した。
+            // 生の Count で見ると、Quest 固有の検出が無いのに空の枠だけ出ることがある
+            var hasIncompatibilities = incompatibilities != null
+                && incompatibilities.Any(i => i.Scope == IncompatibilityScope.Quest);
 
             // 出すものが何も無ければ box ごと出さない（従来通り）
             if (!hasRating && !hasIncompatibilities) return;
@@ -648,13 +651,11 @@ namespace AvatarOmamori.Editor
 
             if (hasIncompatibilities)
             {
-                // Quest 固有の話と、PC でも剥がされる話を混ぜない。
-                // 混ぜると PC しか使わない人が後者を「Quest の話」として読み飛ばす
+                // 「アップロード時に取り除かれるもの（PC / Quest 共通）」は v0.10.0 で
+                // チェック一覧側（UnsupportedComponentCheck）へ移した。
+                // 同じ検出をここにも出すと、Foldout の件数が水増しされる（DEC-071）
                 DrawIncompatibilityGroup(
                     "Quest では使えないもの", incompatibilities, IncompatibilityScope.Quest);
-                DrawIncompatibilityGroup(
-                    "アップロード時に取り除かれるもの（PC / Quest 共通）",
-                    incompatibilities, IncompatibilityScope.AllPlatforms);
             }
 
             EditorGUILayout.EndVertical();
@@ -808,8 +809,12 @@ namespace AvatarOmamori.Editor
             var counts = new Dictionary<string, int>();
             if (report.Pc != null && report.Pc.IsValid) counts["performance_rank_pc"] = 1;
             if (report.Quest != null && report.Quest.IsValid) counts["performance_rank_quest"] = 1;
-            if (report.QuestIncompatibilities.Count > 0)
-                counts["quest_incompatibility"] = report.QuestIncompatibilities.Count;
+            // AllPlatforms スコープの検出は UnsupportedComponentCheck が
+            // detectionsByCheckType 側に計上するため、ここで数えると二重計上になる（v0.10.0）
+            var questOnlyCount = report.QuestIncompatibilities
+                .Count(i => i.Scope == IncompatibilityScope.Quest);
+            if (questOnlyCount > 0)
+                counts["quest_incompatibility"] = questOnlyCount;
 
             if (counts.Count == 0) return;
 

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/AvatarOmamoriWindow.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/AvatarOmamoriWindow.cs
@@ -193,13 +193,13 @@ namespace AvatarOmamori.Editor
         {
             _scrollPos = EditorGUILayout.BeginScrollView(_scrollPos);
 
-            // 表示条件は CountPrimary ではなく生の Count で見る。
-            // 内訳行を1行も取りこぼさないため（見出しの件数は DrawSeverityGroup 側で CountPrimary を使う）
-            if (_errors.Count > 0)
+            // 表示条件は ShouldDrawGroup（CountPrimary > 0）で見る。内訳行（IsDetail）は直前のサマリー行の
+            // 補足という契約なので、サマリー行が1つも無いグループ（内訳行だけ）は文脈のない断片になるため描画しない（DEC-070）
+            if (ShouldDrawGroup(_errors))
                 DrawSeverityGroup("Error", _errors, ref _foldError, new Color(0.9f, 0.2f, 0.2f));
-            if (_warnings.Count > 0)
+            if (ShouldDrawGroup(_warnings))
                 DrawSeverityGroup("Warning", _warnings, ref _foldWarning, new Color(0.9f, 0.7f, 0.1f));
-            if (_infos.Count > 0)
+            if (ShouldDrawGroup(_infos))
                 DrawSeverityGroup("Info", _infos, ref _foldInfo, new Color(0.5f, 0.7f, 1f));
 
             if (_results.Count == 0)
@@ -297,12 +297,17 @@ namespace AvatarOmamori.Editor
         /// </summary>
         private void RunChecks()
         {
-            _results = CheckRunner.RunAll(_avatarRoot);
+            _results = CheckRunner.RunAll(_avatarRoot, out var detections);
             CacheResultsByCategory();
 
             _performanceReport = PerformanceReportBuilder.Build(_avatarRoot);
             EnsureExpandedFactors().Clear(); // 再チェックのたびに「ほか N 件」は畳み直す
-            RecordPerformanceUsage(_performanceReport);
+
+            // チェック側とパフォーマンス側の検出をまとめ、ディスクへの書き込みを1回にする（Issue #35）。
+            // 実行回数を増やすのはこの1箇所だけなので、check_run_count は二重計上されない。
+            UsageStatsRecorder.RecordRun(
+                MergeUsageCounts(detections, BuildPerformanceUsageCounts(_performanceReport)),
+                incrementRunCount: true);
         }
 
         /// <summary>
@@ -322,6 +327,12 @@ namespace AvatarOmamori.Editor
         /// </summary>
         internal static int CountPrimary(List<CheckResult> items)
             => items.Count(r => !r.IsDetail);
+
+        /// <summary>
+        /// Severity グループを描画するかどうか。内訳行（<see cref="CheckResult.IsDetail"/>）は
+        /// 直前のサマリー行の補足という契約なので、サマリー行が1つも無いグループは描画しない。
+        /// </summary>
+        internal static bool ShouldDrawGroup(List<CheckResult> items) => CountPrimary(items) > 0;
 
         private GUIStyle GetSummaryStyle()
         {
@@ -799,14 +810,16 @@ namespace AvatarOmamori.Editor
         }
 
         /// <summary>
-        /// パフォーマンス表示の発火を利用統計に記録する（DEC-069 T-7）。
+        /// パフォーマンス表示の発火に対応する利用統計の件数を組み立てる（DEC-069 T-7）。
         /// キーは ASCII 識別子のみ。アバター名・パス等は一切渡さない（DEC-055 の収集境界を維持）。
+        /// 書き込みは行わない。呼び出し側（<see cref="RunChecks"/>）がチェック側の検出とまとめて
+        /// <see cref="UsageStatsRecorder.RecordRun"/> で1回だけ記録する（Issue #35）。
         /// </summary>
-        private static void RecordPerformanceUsage(AvatarPerformanceReport report)
+        internal static Dictionary<string, int> BuildPerformanceUsageCounts(AvatarPerformanceReport report)
         {
-            if (report == null || !report.IsValid) return;
-
             var counts = new Dictionary<string, int>();
+            if (report == null || !report.IsValid) return counts;
+
             if (report.Pc != null && report.Pc.IsValid) counts["performance_rank_pc"] = 1;
             if (report.Quest != null && report.Quest.IsValid) counts["performance_rank_quest"] = 1;
             // AllPlatforms スコープの検出は UnsupportedComponentCheck が
@@ -816,10 +829,31 @@ namespace AvatarOmamori.Editor
             if (questOnlyCount > 0)
                 counts["quest_incompatibility"] = questOnlyCount;
 
-            if (counts.Count == 0) return;
+            return counts;
+        }
 
-            // CheckRunner.RunAll と同じ実行で呼ばれるため、実行回数を二重計上しない入口を使う
-            UsageStatsRecorder.RecordDetections(counts);
+        /// <summary>利用統計に渡す件数辞書を合算する。同じキーは足し合わせる。</summary>
+        internal static Dictionary<string, int> MergeUsageCounts(
+            IReadOnlyDictionary<string, int> a, IReadOnlyDictionary<string, int> b)
+        {
+            var merged = new Dictionary<string, int>();
+            if (a != null)
+            {
+                foreach (var kv in a)
+                {
+                    merged.TryGetValue(kv.Key, out int cur);
+                    merged[kv.Key] = cur + kv.Value;
+                }
+            }
+            if (b != null)
+            {
+                foreach (var kv in b)
+                {
+                    merged.TryGetValue(kv.Key, out int cur);
+                    merged[kv.Key] = cur + kv.Value;
+                }
+            }
+            return merged;
         }
 
         /// <summary>

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/CheckRunner.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/CheckRunner.cs
@@ -26,26 +26,58 @@ namespace AvatarOmamori.Editor
         }
 
         /// <summary>
-        /// 全ての利用可能なチェックをアバタールートに対して実行し、結果を返す。
-        /// 個別チェックで例外が発生した場合はログに警告を出力し、残りのチェックを続行する。
+        /// 全ての利用可能なチェックをアバタールートに対して実行し、結果を返す（既存シグネチャ・互換維持）。
+        /// このメソッドは利用統計を書き込まない。記録は呼び出し側が <see cref="UsageStatsRecorder.RecordRun"/>
+        /// で1回だけ行う（Issue #35）。
         /// </summary>
         /// <param name="avatarRoot">チェック対象のアバタールート GameObject。</param>
         /// <returns>全チェックの結果を集約したリスト。</returns>
         public static List<CheckResult> RunAll(GameObject avatarRoot)
         {
-            return RunAll(avatarRoot, Checks);
+            return RunAll(avatarRoot, Checks, out _);
+        }
+
+        /// <summary>
+        /// 全ての利用可能なチェックをアバタールートに対して実行し、結果と検出件数を返す。
+        /// このメソッドは利用統計を書き込まない。記録は呼び出し側が <see cref="UsageStatsRecorder.RecordRun"/>
+        /// で1回だけ行う（Issue #35）。
+        /// </summary>
+        /// <param name="avatarRoot">チェック対象のアバタールート GameObject。</param>
+        /// <param name="detectionsByCheckType">チェッククラス名 → 今回の検出件数。呼び出し側の記録に使う。</param>
+        /// <returns>全チェックの結果を集約したリスト。</returns>
+        public static List<CheckResult> RunAll(GameObject avatarRoot, out IReadOnlyDictionary<string, int> detectionsByCheckType)
+        {
+            return RunAll(avatarRoot, Checks, out detectionsByCheckType);
+        }
+
+        /// <summary>
+        /// 指定されたチェック群を実行する（既存 internal・互換維持）。
+        /// テストからフェイクチェックを注入して例外分離などを検証できるよう分離している。
+        /// このメソッドは利用統計を書き込まない。記録は呼び出し側が <see cref="UsageStatsRecorder.RecordRun"/>
+        /// で1回だけ行う（Issue #35）。
+        /// </summary>
+        internal static List<CheckResult> RunAll(GameObject avatarRoot, IEnumerable<IAvatarCheck> checks)
+        {
+            return RunAll(avatarRoot, checks, out _);
         }
 
         /// <summary>
         /// 指定されたチェック群を実行する本体。
         /// テストからフェイクチェックを注入して例外分離などを検証できるよう分離している。
+        ///
+        /// <para>
+        /// このメソッドは利用統計を書き込まない。記録は呼び出し側が <see cref="UsageStatsRecorder.RecordRun"/>
+        /// で1回だけ行う（Issue #35）。以前はここで <see cref="UsageStatsRecorder.RecordCheckRun"/> を直接呼んでいたが、
+        /// <see cref="AvatarOmamoriWindow.RunChecks"/> 側のパフォーマンス集計と合わせて1回の実行で2回ディスクに
+        /// 書き込まれてしまっていたため、書き込み責務を呼び出し側の1箇所に一本化した。
+        /// </para>
         /// </summary>
-        internal static List<CheckResult> RunAll(GameObject avatarRoot, IEnumerable<IAvatarCheck> checks)
+        internal static List<CheckResult> RunAll(GameObject avatarRoot, IEnumerable<IAvatarCheck> checks, out IReadOnlyDictionary<string, int> detectionsByCheckType)
         {
             var results = new List<CheckResult>();
             // チェック種別ごとの検出件数（利用統計用）。キーはチェッククラスの型名のみを使い、
             // ユーザーのアセット名などは一切載せない（個人情報を集めない設計・DEC-055）。
-            var detectionsByCheckType = new Dictionary<string, int>();
+            var detections = new Dictionary<string, int>();
 
             foreach (var check in checks)
             {
@@ -56,12 +88,18 @@ namespace AvatarOmamori.Editor
                 {
                     // yield 実装の二重実行を避けるため、ここで1度だけ列挙する
                     var checkResults = check.Execute(avatarRoot).ToList();
+
+                    // IsDetail は「直前のサマリー行の内訳」という契約。サマリー行なしの内訳は UI に出さない（ShouldDrawGroup）ため、
+                    // 黙って情報が落ちないよう開発時に気づける形で警告する（DEC-070）
+                    if (checkResults.Count > 0 && checkResults[0].IsDetail)
+                        Debug.LogWarning($"[AvatarOmamori] Check '{check.DisplayName}' returned a detail row without a summary row.");
+
                     results.AddRange(checkResults);
                     if (checkResults.Count > 0)
                     {
                         var key = check.GetType().Name;
-                        detectionsByCheckType.TryGetValue(key, out int cur);
-                        detectionsByCheckType[key] = cur + checkResults.Count;
+                        detections.TryGetValue(key, out int cur);
+                        detections[key] = cur + checkResults.Count;
                     }
                 }
                 catch (Exception e)
@@ -70,9 +108,7 @@ namespace AvatarOmamori.Editor
                 }
             }
 
-            // 利用統計に「チェック実行1回＋種別ごとの検出件数」を記録する（opt-out 中は内部で何もしない）
-            UsageStatsRecorder.RecordCheckRun(detectionsByCheckType);
-
+            detectionsByCheckType = detections;
             return results;
         }
 

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/UnsupportedComponentCheck.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/UnsupportedComponentCheck.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AvatarOmamori.Editor.Performance;
+using UnityEngine;
+
+namespace AvatarOmamori.Editor.Checks
+{
+    /// <summary>
+    /// VRChat がアバターで許可していないコンポーネント（アップロード時に取り除かれるもの）を報告する。
+    ///
+    /// <para>
+    /// 判定は <see cref="QuestCompatibilityScanner"/> に委譲し、
+    /// <see cref="IncompatibilityScope.AllPlatforms"/> の項目だけを拾う。
+    /// <b>スキャナ側の判定ロジックには手を入れない。</b>
+    /// SDK 判定（<c>FindIllegalComponents</c>）と自前リストのどちらを先に <c>reported</c> へ登録するかが
+    /// ビルドターゲットで入れ替わる設計（DEC-075）になっており、判定を切り出すと Standalone で
+    /// MeshCollider が「Quest では無効になる Collider（物理）… PC では動作します」と誤って説明される。
+    /// </para>
+    /// <para>
+    /// 自動修正は用意しない。PC 版で意図して使っている可能性があり、消すと壊れるため（Issue #36）。
+    /// </para>
+    /// </summary>
+    public sealed class UnsupportedComponentCheck : IAvatarCheck
+    {
+        /// <summary>内訳として常時表示する型の数。これを超えた分は「ほか N 種類」1行にまとめる。</summary>
+        private const int VisibleTypeCount = 5;
+
+        /// <inheritdoc/>
+        public string DisplayName => "[SDK] 非対応コンポーネントチェック";
+
+        /// <inheritdoc/>
+        /// <remarks>VRChat SDK は asmdef の必須参照なので、常に実行できる。</remarks>
+        public bool IsAvailable() => true;
+
+        /// <inheritdoc/>
+        public IEnumerable<CheckResult> Execute(GameObject avatarRoot)
+        {
+            return BuildResults(QuestCompatibilityScanner.Scan(avatarRoot));
+        }
+
+        /// <summary>
+        /// スキャン結果を <see cref="CheckResult"/> 列に変換する本体。
+        /// <see cref="QuestCompatibilityScanner.Scan(GameObject)"/> は実行中のエディタのアクティブ
+        /// ビルドターゲットに依存するため、テストからスキャン結果を注入できるよう分離している
+        /// （<c>QuestCompatibilityScannerTests</c> が <c>Scan(GameObject, bool)</c> を使うのと同じ理由）。
+        /// </summary>
+        internal static IEnumerable<CheckResult> BuildResults(IReadOnlyList<QuestIncompatibility> scanResults)
+        {
+            if (scanResults == null) yield break;
+
+            var components = scanResults
+                .Where(i => i.Scope == IncompatibilityScope.AllPlatforms)
+                .SelectMany(i => i.Components)
+                .Where(c => c != null)
+                .ToList();
+
+            if (components.Count == 0) yield break;
+
+            // 個数の降順 → 型名の序数昇順。QuestCompatibilityScanner の内訳の並べ方に合わせる
+            var groups = components
+                .GroupBy(c => c.GetType().Name, StringComparer.Ordinal)
+                .OrderByDescending(g => g.Count())
+                .ThenBy(g => g.Key, StringComparer.Ordinal)
+                .ToList();
+
+            // サマリー行。件数に数えるのはこの1行だけ（IsDetail = false）。
+            // DynamicBone を 30 本入れたアバターで「30 Warning」になると、DEC-071 で直した
+            // 件数の水増しが再発するため、1コンポーネント1行にはしない
+            yield return new CheckResult(
+                Severity.Warning,
+                $"[SDK] VRChat が対応していないコンポーネントが {components.Count} 個あります"
+                + $"（{groups.Count} 種類）。"
+                + "アップロード時に取り除かれるため、入れたはずの機能がアバターで動きません。");
+
+            // 内訳行。件数には数えず（IsDetail = true）、型ごとに1行だけ出す。
+            // 「選択」で Ping できるのはその型の先頭1件のみ（CheckResult.TargetObject が単数のため。
+            // 複数ターゲット対応は v0.10.0 のスコープ外として Issue に残す）
+            foreach (var group in groups.Take(VisibleTypeCount))
+            {
+                yield return new CheckResult(
+                    Severity.Warning,
+                    $"{group.Key} ×{group.Count()}",
+                    group.First().gameObject,
+                    isDetail: true);
+            }
+
+            var hiddenTypeCount = groups.Count - VisibleTypeCount;
+            if (hiddenTypeCount > 0)
+            {
+                yield return new CheckResult(
+                    Severity.Warning,
+                    $"ほか {hiddenTypeCount} 種類",
+                    isDetail: true);
+            }
+        }
+    }
+}

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/UnsupportedComponentCheck.cs.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/UnsupportedComponentCheck.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 92dfd06c2d3a60749b00f236d2ce6f8e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/Performance/QuestCompatibilityScanner.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/Performance/QuestCompatibilityScanner.cs
@@ -17,7 +17,11 @@ namespace AvatarOmamori.Editor.Performance
         /// <summary>Quest / iOS でのみ問題になる。</summary>
         Quest,
 
-        /// <summary>PC / Quest を問わず、アップロード時に取り除かれる。</summary>
+        /// <summary>
+        /// PC / Quest を問わず、アップロード時に取り除かれる。
+        /// v0.10.0 以降、このスコープはパフォーマンス表示の見出し分けではなく、
+        /// <c>UnsupportedComponentCheck</c>（チェック一覧側）へ振り分けるためのタグとして使う。
+        /// </summary>
         AllPlatforms
     }
 
@@ -45,19 +49,29 @@ namespace AvatarOmamori.Editor.Performance
         /// <summary>「調べる」で開く公式ドキュメント。適切な案内先が無い場合は null（ボタンを出さない）。</summary>
         public string DocumentUrl { get; }
 
+        /// <summary>
+        /// この項目の元になったコンポーネント。渡されなければ空。
+        /// <see cref="Targets"/> は「選択」用に GameObject へ寄せて重複排除したものなので、
+        /// ここから「型ごとの個数」を復元することはできない。
+        /// 型別の内訳を組み立てるチェック側（<c>UnsupportedComponentCheck</c>）のために持つ。
+        /// </summary>
+        public IReadOnlyList<Component> Components { get; }
+
         public QuestIncompatibility(
             string label,
             int count,
             string detail,
             IReadOnlyList<UnityEngine.Object> targets,
             IncompatibilityScope scope = IncompatibilityScope.Quest,
-            string documentUrl = null)
+            string documentUrl = null,
+            IReadOnlyList<Component> components = null)
         {
             Label = label;
             Count = count;
             Detail = detail;
             Targets = targets ?? Array.Empty<UnityEngine.Object>();
             Scope = scope;
+            Components = components ?? Array.Empty<Component>();
             DocumentUrl = documentUrl ?? (scope == IncompatibilityScope.Quest
                 ? PerformanceCategoryLabels.QuestDocUrl
                 : null);
@@ -309,7 +323,9 @@ namespace AvatarOmamori.Editor.Performance
                 illegal.Count,
                 $"{detail} — PC / Quest を問わず、アップロード時に取り除かれます",
                 illegal.Select(c => (UnityEngine.Object)c.gameObject).Distinct().ToList(),
-                IncompatibilityScope.AllPlatforms));
+                IncompatibilityScope.AllPlatforms,
+                // 型ごとの内訳は UnsupportedComponentCheck 側で組み立てる（判定はここに残す）
+                components: illegal));
         }
     }
 }

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/UsageStatsRecorder.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/UsageStatsRecorder.cs
@@ -58,53 +58,35 @@ namespace AvatarOmamori.Editor
         // ───────────────────────────── 記録 API ─────────────────────────────
 
         /// <summary>
-        /// チェック一括実行（<see cref="CheckRunner.RunAll"/>）1回分を記録する。
-        /// <paramref name="detectionsByCheckType"/> はチェッククラス名 → そのチェックが今回検出した件数。
-        /// opt-out 中は何もしない。
+        /// 記録の統合入口（Issue #35）。<see cref="RecordCheckRun"/> / <see cref="RecordDetections"/> は
+        /// どちらもこのメソッドへ委譲する薄いラッパー。
+        /// 呼び出し元（<see cref="AvatarOmamoriWindow.RunChecks"/>）が1回の実行につき1回だけ呼ぶことで、
+        /// ディスクへの書き込みを1往復に抑える。
         /// </summary>
-        public static void RecordCheckRun(IReadOnlyDictionary<string, int> detectionsByCheckType)
+        /// <param name="detectionsByKey">キー → 今回の検出件数。null 可。</param>
+        /// <param name="incrementRunCount">true ならチェック実行回数（<c>check_run_count</c>）を1増やす。</param>
+        public static void RecordRun(IReadOnlyDictionary<string, int> detectionsByKey, bool incrementRunCount)
         {
             var stats = Load();
             if (stats.OptOut) return;
 
-            stats.CheckRunCount++;
-            if (detectionsByCheckType != null)
+            if (incrementRunCount) stats.CheckRunCount++;
+
+            // 実行回数が増えるなら、検出が1件も無くても「実行された」事実は保存する必要がある。
+            // 逆に実行回数を増やさない呼び出し（RecordDetections 由来）は、加算対象が無ければ何も変わらないので保存しない。
+            var changed = incrementRunCount;
+
+            if (detectionsByKey != null)
             {
-                foreach (var kv in detectionsByCheckType)
+                foreach (var kv in detectionsByKey)
                 {
                     if (kv.Value <= 0) continue;
                     var key = SanitizeKey(kv.Key);
                     if (key == null) continue; // 識別子として不正なキーは捨てる（個人情報混入の最終防波堤）
                     stats.DetectionCounts.TryGetValue(key, out int cur);
                     stats.DetectionCounts[key] = cur + kv.Value;
+                    changed = true;
                 }
-            }
-
-            Touch(stats);
-            Save(stats);
-        }
-
-        /// <summary>
-        /// 検出件数だけを加算する（チェック実行回数は増やさない）。
-        /// <see cref="CheckRunner"/> を経由しない機能（パフォーマンス表示など）から呼ぶ。
-        /// <see cref="RecordCheckRun"/> と同じ実行で併用しても check_run_count が二重計上されないようにするための入口。
-        /// opt-out 中は何もしない。
-        /// </summary>
-        public static void RecordDetections(IReadOnlyDictionary<string, int> detectionsByKey)
-        {
-            var stats = Load();
-            if (stats.OptOut) return;
-            if (detectionsByKey == null) return;
-
-            var changed = false;
-            foreach (var kv in detectionsByKey)
-            {
-                if (kv.Value <= 0) continue;
-                var key = SanitizeKey(kv.Key);
-                if (key == null) continue; // 識別子として不正なキーは捨てる（個人情報混入の最終防波堤）
-                stats.DetectionCounts.TryGetValue(key, out int cur);
-                stats.DetectionCounts[key] = cur + kv.Value;
-                changed = true;
             }
 
             if (!changed) return;
@@ -112,6 +94,25 @@ namespace AvatarOmamori.Editor
             Touch(stats);
             Save(stats);
         }
+
+        /// <summary>
+        /// チェック一括実行（<see cref="CheckRunner.RunAll"/>）1回分を記録する。
+        /// <paramref name="detectionsByCheckType"/> はチェッククラス名 → そのチェックが今回検出した件数。
+        /// opt-out 中は何もしない。
+        /// 実体は <see cref="RecordRun"/>（<c>incrementRunCount: true</c>）への委譲。
+        /// </summary>
+        public static void RecordCheckRun(IReadOnlyDictionary<string, int> detectionsByCheckType)
+            => RecordRun(detectionsByCheckType, incrementRunCount: true);
+
+        /// <summary>
+        /// 検出件数だけを加算する（チェック実行回数は増やさない）。
+        /// <see cref="CheckRunner"/> を経由しない機能（パフォーマンス表示など）から呼ぶ。
+        /// <see cref="RecordCheckRun"/> と同じ実行で併用しても check_run_count が二重計上されないようにするための入口。
+        /// opt-out 中は何もしない。
+        /// 実体は <see cref="RecordRun"/>（<c>incrementRunCount: false</c>）への委譲。
+        /// </summary>
+        public static void RecordDetections(IReadOnlyDictionary<string, int> detectionsByKey)
+            => RecordRun(detectionsByKey, incrementRunCount: false);
 
         /// <summary>
         /// 自動修正1回分を記録する。<paramref name="checkTypeName"/> は修正を提供したチェッククラス名。

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/CheckRunnerDiscoveryTests.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/CheckRunnerDiscoveryTests.cs
@@ -7,10 +7,10 @@ namespace AvatarOmamori.Tests.Editor
     public class CheckRunnerDiscoveryTests
     {
         [Test]
-        public void Checks_実装済みの10チェックが全て検出される()
+        public void Checks_実装済みの11チェックが全て検出される()
         {
             // Checks はアセンブリ内の IAvatarCheck 実装をリフレクション列挙するだけで
-            // IsAvailable() は見ないため、MA 未インストール環境でも10件全てが列挙される
+            // IsAvailable() は見ないため、MA 未インストール環境でも11件全てが列挙される
             var names = CheckRunner.Checks.Select(c => c.GetType().Name).ToList();
 
             var expected = new[]
@@ -25,6 +25,7 @@ namespace AvatarOmamori.Tests.Editor
                 "MAMenuItemUnboundCheck",
                 "MAObjectToggleCheck",
                 "MAUnsetupAccessoryCheck",
+                "UnsupportedComponentCheck",
             };
 
             foreach (var name in expected)

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/CheckRunnerRunAllTests.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/CheckRunnerRunAllTests.cs
@@ -53,6 +53,18 @@ namespace AvatarOmamori.Tests.Editor
             Assert.IsFalse(unavailable.Executed);
         }
 
+        [Test]
+        public void RunAll_サマリー行なしで内訳行だけを返すチェックは警告を出す()
+        {
+            // IsDetail は「直前のサマリー行の内訳」という契約（DEC-070）。契約違反を開発時に気づけるようにする
+            var checks = new IAvatarCheck[] { new DetailOnlyCheck() };
+
+            LogAssert.Expect(LogType.Warning, new Regex("DetailOnlyCheck"));
+            var results = CheckRunner.RunAll(_root, checks);
+
+            Assert.AreEqual(1, results.Count);
+        }
+
         // ネストした private クラスなので CheckRunner.DiscoverChecks（メインアセンブリのみ走査）には
         // 拾われず、本物のチェック一覧を汚さない
         private sealed class FakeCheck : IAvatarCheck
@@ -80,6 +92,19 @@ namespace AvatarOmamori.Tests.Editor
             public IEnumerable<CheckResult> Execute(GameObject avatarRoot)
             {
                 throw new InvalidOperationException("boom");
+            }
+        }
+
+        private sealed class DetailOnlyCheck : IAvatarCheck
+        {
+            public string DisplayName => "DetailOnlyCheck";
+
+            public bool IsAvailable() => true;
+
+            public IEnumerable<CheckResult> Execute(GameObject avatarRoot)
+            {
+                // サマリー行なしで内訳行だけを返す契約違反のケース
+                return new[] { new CheckResult(Severity.Warning, "内訳のみ", isDetail: true) };
             }
         }
     }

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/SummaryCountTests.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/SummaryCountTests.cs
@@ -51,5 +51,39 @@ namespace AvatarOmamori.Tests.Editor
 
             Assert.IsFalse(result.IsDetail);
         }
+
+        [Test]
+        public void 内訳行だけのリストはグループを描画しない()
+        {
+            // サマリー行が無い＝内訳行だけが取り残されたケース（DEC-070）。
+            // 文脈のない断片になるため ShouldDrawGroup は false を返す必要がある
+            var items = new List<CheckResult>
+            {
+                new CheckResult(Severity.Error, "重複した VRC Avatar Descriptor: Avatar/Body", isDetail: true),
+                new CheckResult(Severity.Error, "重複した VRC Avatar Descriptor: Avatar/Hair", isDetail: true),
+            };
+
+            Assert.IsFalse(AvatarOmamoriWindow.ShouldDrawGroup(items));
+        }
+
+        [Test]
+        public void サマリー行があればグループを描画する()
+        {
+            var items = new List<CheckResult>
+            {
+                new CheckResult(Severity.Error, "VRC Avatar Descriptor が 3 個見つかりました"),
+                new CheckResult(Severity.Error, "重複した VRC Avatar Descriptor: Avatar/Body", isDetail: true),
+                new CheckResult(Severity.Error, "重複した VRC Avatar Descriptor: Avatar/Hair", isDetail: true),
+            };
+
+            Assert.IsTrue(AvatarOmamoriWindow.ShouldDrawGroup(items));
+            Assert.AreEqual(1, AvatarOmamoriWindow.CountPrimary(items));
+        }
+
+        [Test]
+        public void 空リストはグループを描画しない()
+        {
+            Assert.IsFalse(AvatarOmamoriWindow.ShouldDrawGroup(new List<CheckResult>()));
+        }
     }
 }

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/UnsupportedComponentCheckTests.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/UnsupportedComponentCheckTests.cs
@@ -1,0 +1,226 @@
+using System.Collections.Generic;
+using System.Linq;
+using AvatarOmamori.Editor;
+using AvatarOmamori.Editor.Checks;
+using AvatarOmamori.Editor.Performance;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace AvatarOmamori.Tests.Editor
+{
+    /// <summary>
+    /// VRChat 非対応コンポーネント検出（Issue #36）のテスト。
+    ///
+    /// <para>
+    /// 判定そのものは <see cref="QuestCompatibilityScanner"/>（＝SDK の <c>FindIllegalComponents</c>）の
+    /// 担当で、<c>QuestCompatibilityScannerTests</c> で固定済み。ここで固定するのは
+    /// <b>スキャン結果を CheckResult に変換する部分</b>（サマリー＋型別内訳・件数の数え方・並び順）。
+    /// そのため大半のケースはスキャン結果を組み立てて <c>BuildResults</c> に直接渡し、
+    /// SDK とアクティブビルドターゲットに依存しないようにしている。
+    /// </para>
+    /// </summary>
+    public class UnsupportedComponentCheckTests
+    {
+        private GameObject _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new GameObject("Avatar");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_root != null) Object.DestroyImmediate(_root);
+        }
+
+        /// <summary>子オブジェクトに <typeparamref name="T"/> を付けて返す。</summary>
+        private T AddChild<T>(string name) where T : Component
+        {
+            var go = new GameObject(name);
+            go.transform.SetParent(_root.transform);
+            return go.AddComponent<T>();
+        }
+
+        /// <summary>AllPlatforms スコープのスキャン結果を1件組み立てる。</summary>
+        private static List<QuestIncompatibility> AllPlatformsScan(params Component[] components)
+        {
+            return new List<QuestIncompatibility>
+            {
+                new QuestIncompatibility(
+                    "VRChat が対応していないコンポーネント",
+                    components.Length,
+                    "（テスト）",
+                    components.Select(c => (Object)c.gameObject).Distinct().ToList(),
+                    IncompatibilityScope.AllPlatforms,
+                    components: components)
+            };
+        }
+
+        private static List<CheckResult> Run(List<QuestIncompatibility> scan)
+        {
+            return UnsupportedComponentCheck.BuildResults(scan).ToList();
+        }
+
+        [Test]
+        public void 非対応コンポーネントが無ければ何も報告しない()
+        {
+            Assert.IsEmpty(Run(new List<QuestIncompatibility>()));
+        }
+
+        [Test]
+        public void Questスコープの項目は拾わない()
+        {
+            // 「Quest では使えないもの」はパフォーマンスセクションの担当、
+            // こちらでも拾うと同じ検出が2箇所に出て件数が水増しされる（DEC-071）
+            var light = AddChild<Light>("Light");
+            var scan = new List<QuestIncompatibility>
+            {
+                new QuestIncompatibility(
+                    "Quest では無効になる Light", 1, "（テスト）",
+                    new List<Object> { light.gameObject },
+                    IncompatibilityScope.Quest,
+                    components: new Component[] { light })
+            };
+
+            Assert.IsEmpty(Run(scan));
+        }
+
+        [Test]
+        public void 件数に数えるのはサマリーの1行だけ()
+        {
+            // 1コンポーネント1行にすると、DynamicBone を 30 本入れたアバターで「30 Warning」になり、
+            // DEC-071 で直した件数の水増しが再発する
+            var results = Run(AllPlatformsScan(
+                AddChild<MeshCollider>("A"), AddChild<MeshCollider>("B"), AddChild<MeshCollider>("C"),
+                AddChild<Light>("D")));
+
+            Assert.AreEqual(1, results.Count(r => !r.IsDetail), "サマリー行は1行だけであるべき");
+            Assert.AreEqual(2, results.Count(r => r.IsDetail), "内訳行は型ごとに1行であるべき");
+        }
+
+        [Test]
+        public void サマリーに合計個数と型の種類数を書く()
+        {
+            var summary = Run(AllPlatformsScan(
+                AddChild<MeshCollider>("A"), AddChild<MeshCollider>("B"), AddChild<MeshCollider>("C"),
+                AddChild<Light>("D"))).First(r => !r.IsDetail);
+
+            StringAssert.Contains("4 個", summary.Message);
+            StringAssert.Contains("2 種類", summary.Message);
+        }
+
+        [Test]
+        public void サマリー行には選択対象を持たせない()
+        {
+            // 対象は型ごとの内訳行が持つ。サマリーに代表1件をぶら下げると
+            // 「なぜこの1件だけが選ばれるのか」を説明できない
+            var summary = Run(AllPlatformsScan(AddChild<MeshCollider>("A"))).First(r => !r.IsDetail);
+
+            Assert.IsNull(summary.TargetObject);
+        }
+
+        [Test]
+        public void 内訳は個数の降順で型ごとに1行ずつ出す()
+        {
+            var results = Run(AllPlatformsScan(
+                AddChild<Light>("A"),
+                AddChild<MeshCollider>("B"), AddChild<MeshCollider>("C"), AddChild<MeshCollider>("D"),
+                AddChild<BoxCollider>("E"), AddChild<BoxCollider>("F")));
+
+            CollectionAssert.AreEqual(
+                new[] { "MeshCollider ×3", "BoxCollider ×2", "Light ×1" },
+                results.Where(r => r.IsDetail).Select(r => r.Message).ToList());
+        }
+
+        [Test]
+        public void 内訳行はその型の先頭1件を選択対象にする()
+        {
+            var first = AddChild<MeshCollider>("First");
+            var second = AddChild<MeshCollider>("Second");
+
+            var detail = Run(AllPlatformsScan(first, second)).Single(r => r.IsDetail);
+
+            Assert.AreSame(first.gameObject, detail.TargetObject);
+        }
+
+        [Test]
+        public void 型が6種類以上あるときは上位5型とほかN種類にまとめる()
+        {
+            // 縦に伸びて 493×430 のウィンドウから溢れるのを防ぐ。サマリーの件数には影響させない。
+            // 同数の型は型名の序数昇順（BoxCollider → Camera → CapsuleCollider → Light → Rigidbody）
+            var results = Run(AllPlatformsScan(
+                AddChild<MeshCollider>("A"), AddChild<MeshCollider>("B"),
+                AddChild<BoxCollider>("C"),
+                AddChild<Camera>("D"),
+                AddChild<CapsuleCollider>("E"),
+                AddChild<Light>("F"),
+                AddChild<Rigidbody>("G")));
+
+            var details = results.Where(r => r.IsDetail).ToList();
+
+            Assert.AreEqual(6, details.Count, "上位5型 +「ほか N 種類」の1行になるべき");
+            Assert.AreEqual("MeshCollider ×2", details[0].Message);
+            Assert.AreEqual("ほか 1 種類", details.Last().Message);
+            StringAssert.Contains("6 種類", results.First(r => !r.IsDetail).Message);
+        }
+
+        [Test]
+        public void まとめ行は選択対象を持たない()
+        {
+            var results = Run(AllPlatformsScan(
+                AddChild<MeshCollider>("A"), AddChild<BoxCollider>("B"), AddChild<Camera>("C"),
+                AddChild<CapsuleCollider>("D"), AddChild<Light>("E"), AddChild<Rigidbody>("F")));
+
+            var overflow = results.Last();
+            StringAssert.StartsWith("ほか", overflow.Message);
+            Assert.IsNull(overflow.TargetObject);
+        }
+
+        [Test]
+        public void 深刻度はすべてWarningになる()
+        {
+            // アップロード自体は通るので Error ではない（Issue #36 の指定）
+            var results = Run(AllPlatformsScan(AddChild<MeshCollider>("A"), AddChild<Light>("B")));
+
+            Assert.IsNotEmpty(results);
+            Assert.IsTrue(results.All(r => r.Severity == Severity.Warning));
+        }
+
+        [Test]
+        public void 自動修正は提供しない()
+        {
+            // PC 版で意図して使っている可能性があり、勝手に消すと壊れる（Issue #36）
+            var results = Run(AllPlatformsScan(AddChild<MeshCollider>("A")));
+
+            Assert.IsTrue(results.All(r => !r.HasFix));
+        }
+
+        [Test]
+        public void 実スキャナ経由でもMeshColliderを検出する()
+        {
+            // BuildResults 単体ではなく、QuestCompatibilityScanner の AllPlatforms 項目が
+            // 実際にこのチェックへ流れてくることを固定する。
+            // Scan(GameObject) はアクティブビルドターゲットに依存するため Standalone 相当を明示する
+            AddChild<MeshCollider>("Mesh");
+
+            var results = Run(QuestCompatibilityScanner.Scan(_root, isMobileBuildTarget: false));
+
+            Assert.AreEqual(1, results.Count(r => !r.IsDetail));
+            StringAssert.Contains("MeshCollider ×1", results.Single(r => r.IsDetail).Message);
+        }
+
+        [Test]
+        public void 通常のアバター構成では実スキャナ経由でも何も出ない()
+        {
+            // 通常の改変アバターの構成要素はほぼすべて SDK のホワイトリスト側にある
+            // （W0 実測: 実アバター3体で 0 件）。「普段は静か、踏んだときだけ出る」を壊さない。
+            // BoxCollider は PC では動くので Quest スコープ側の担当であり、ここには出てこない
+            AddChild<SkinnedMeshRenderer>("Body");
+            AddChild<BoxCollider>("Collider");
+
+            Assert.IsEmpty(Run(QuestCompatibilityScanner.Scan(_root, isMobileBuildTarget: false)));
+        }
+    }
+}

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/UnsupportedComponentCheckTests.cs.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/UnsupportedComponentCheckTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 09bc02ac8488b9944a3912762b633f9b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/UsageStatsSingleWriteTests.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/UsageStatsSingleWriteTests.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using AvatarOmamori.Editor;
+
+namespace AvatarOmamori.Tests.Editor
+{
+    /// <summary>
+    /// 利用統計の書き込みを1往復に統合したこと（Issue #35）を固定するテスト。
+    /// もともと入口を <see cref="UsageStatsRecorder.RecordCheckRun"/> と
+    /// <see cref="UsageStatsRecorder.RecordDetections"/> の2つに分けていたのは check_run_count の
+    /// 二重計上を避けるためだった。ここが崩れると、書き込み回数を1回に統合した意味そのものが失われる。
+    /// </summary>
+    public class UsageStatsSingleWriteTests
+    {
+        private string _dir;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _dir = UsageStatsTestUtil.BeginOverride();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            UsageStatsTestUtil.EndOverride(_dir);
+        }
+
+        [Test]
+        public void RecordRun_チェック側とパフォーマンス側の検出を1回で渡すとcheck_run_countは1だけ増える()
+        {
+            var checkDetections = new Dictionary<string, int>
+            {
+                { "MissingScriptCheck", 2 },
+            };
+            var performanceCounts = new Dictionary<string, int>
+            {
+                { "performance_rank_pc", 1 },
+                { "performance_rank_quest", 1 },
+            };
+
+            var merged = AvatarOmamoriWindow.MergeUsageCounts(checkDetections, performanceCounts);
+            UsageStatsRecorder.RecordRun(merged, incrementRunCount: true);
+
+            var stats = UsageStatsRecorder.GetSnapshot();
+            Assert.AreEqual(1, stats.CheckRunCount);
+            Assert.AreEqual(2, stats.DetectionCounts["MissingScriptCheck"]);
+            Assert.AreEqual(1, stats.DetectionCounts["performance_rank_pc"]);
+            Assert.AreEqual(1, stats.DetectionCounts["performance_rank_quest"]);
+        }
+
+        [Test]
+        public void RecordRun_incrementRunCountがfalseならcheck_run_countは増えない()
+        {
+            UsageStatsRecorder.RecordRun(
+                new Dictionary<string, int> { { "performance_rank_pc", 1 } },
+                incrementRunCount: false);
+
+            var stats = UsageStatsRecorder.GetSnapshot();
+            Assert.AreEqual(0, stats.CheckRunCount);
+            Assert.AreEqual(1, stats.DetectionCounts["performance_rank_pc"]);
+        }
+
+        [Test]
+        public void 旧来のRecordCheckRunとRecordDetectionsを同じ実行で併用してもcheck_run_countは1のまま()
+        {
+            // 委譲後も、CheckRunner.RunAll と AvatarOmamoriWindow 側の記録を同じ実行で併用したときの
+            // 従来の保証（実行回数を二重計上しない）が維持されていることを固定する
+            UsageStatsRecorder.RecordCheckRun(new Dictionary<string, int> { { "MissingScriptCheck", 1 } });
+            UsageStatsRecorder.RecordDetections(new Dictionary<string, int> { { "performance_rank_pc", 1 } });
+
+            var stats = UsageStatsRecorder.GetSnapshot();
+            Assert.AreEqual(1, stats.CheckRunCount);
+            Assert.AreEqual(1, stats.DetectionCounts["MissingScriptCheck"]);
+            Assert.AreEqual(1, stats.DetectionCounts["performance_rank_pc"]);
+        }
+
+        [Test]
+        public void MergeUsageCounts_同じキーは合算されnull引数は空として扱われる()
+        {
+            var a = new Dictionary<string, int> { { "foo", 2 }, { "bar", 1 } };
+            var b = new Dictionary<string, int> { { "foo", 3 } };
+
+            var merged = AvatarOmamoriWindow.MergeUsageCounts(a, b);
+            Assert.AreEqual(5, merged["foo"]);
+            Assert.AreEqual(1, merged["bar"]);
+
+            var mergedWithNullA = AvatarOmamoriWindow.MergeUsageCounts(null, b);
+            Assert.AreEqual(3, mergedWithNullA["foo"]);
+
+            var mergedWithNullB = AvatarOmamoriWindow.MergeUsageCounts(a, null);
+            Assert.AreEqual(2, mergedWithNullB["foo"]);
+            Assert.AreEqual(1, mergedWithNullB["bar"]);
+
+            var mergedBothNull = AvatarOmamoriWindow.MergeUsageCounts(null, null);
+            Assert.IsEmpty(mergedBothNull);
+        }
+    }
+}

--- a/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/UsageStatsSingleWriteTests.cs.meta
+++ b/Packages/com.tsukumodo.avatar-omamori/Tests/Editor/UsageStatsSingleWriteTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2cc545d62a52408c896609ac2e175ef3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
v0.10.0 W1 の系列B＋C。パフォーマンスセクションの「アップロード時に取り除かれるもの（PC / Quest 共通）」をチェック一覧側の独立した Warning に昇格させ（Issue #36）、あわせて利用統計の書き込みの1往復統合（Issue #35）と、Severity グループの表示条件の潜在バグ修正（DEC-070）を積んでいます。

## 変更内容

### 1. VRChat 非対応コンポーネント検出の昇格（Issue #36 / T-5〜T-7）

`Editor/Checks/UnsupportedComponentCheck.cs` を新設しました。`QuestCompatibilityScanner.Scan()` の結果から `Scope == AllPlatforms` の項目を拾い、サマリー1行（件数に数える）と型ごとの内訳行（`IsDetail` ＝ 件数に数えない）に展開します。型が6種類以上あるときは上位5型と「ほか N 種類」の1行にまとめます。自動修正は用意していません。PC 版で意図して使っている可能性があり、消すと壊れるためです（Issue #36 の指定）。

1コンポーネント1 Warning にしていないのは、DynamicBone を30本入れたアバターで「30 Warning」になると、#31 で直した件数の水増しが再発するからです。

**スキャナの判定ロジックには手を入れていません。** `AddSdkIllegalComponents` を新チェックへ移す素直な実装は Standalone でデグレします。現在のロジックは Standalone では SDK 判定を先に `reported` へ登録し、自前リストがその残りだけを見る順序になっているため、SDK 判定を外すと `MeshCollider` が自前リストの `Collider（物理）` に拾われ、「Quest では無効になる Collider（物理） … PC では動作します」という誤った説明になります。実際には MeshCollider は PC でも剥がされます。

`QuestIncompatibility` に `Components` を追加しました。既存の `Targets` は「選択」用に GameObject へ寄せて重複排除済みで、`Detail` も上位3型の文字列しか持たないため、サマリーの「（N 種類）」も型別の内訳もそこからは復元できません。内訳を組み立てるためのデータを渡すだけで、判定には一切関与しません。

`AvatarOmamoriWindow.DrawPlatformBlock` から `AllPlatforms` の見出しを削除しました。これで同じ検出がチェック一覧とパフォーマンスの両方に出ることがなくなり、件数の水増しが構造的に起きなくなります。あわせて `hasIncompatibilities` の判定を Quest スコープ限定にしています。生の `Count` で見ると、Quest 固有の検出が無いのに空の枠だけが出ることがあるためです。

`RecordPerformanceUsage` の `quest_incompatibility` を `Scope == Quest` 限定に変更しました。変えないと同じ検出が `detectionsByCheckType["UnsupportedComponentCheck"]` と二重計上されます。スキーマ v1 のキー構成は変わらず、値の意味だけが v0.10.0 で変わります。

### 2. 利用統計の書き込みを1往復に統合（Issue #35 / T-8）

**「利用統計を書き込むのは `AvatarOmamoriWindow.RunChecks()` の1箇所だけ」という不変条件にしました。**

- `UsageStatsRecorder.RecordRun(detections, incrementRunCount)` を統合入口として新設し、既存の `RecordCheckRun` / `RecordDetections` は public API なので残したままこれへ委譲させています
- `CheckRunner.RunAll` は利用統計を書き込まなくなり、集めた検出件数を `out` で呼び出し側に渡すだけになりました。既存シグネチャは互換のため残しています
- `RunChecks()` がチェック側の検出とパフォーマンス側の件数をマージし、`RecordRun(..., incrementRunCount: true)` を1回だけ呼びます

**公開メソッドの副作用が消える変更**なので、`CheckRunner.RunAll` の XML doc に「このメソッドは利用統計を書き込まない。記録は呼び出し側が1回だけ行う」と明記しています。

W0 の実測では、`RunChecks()` warm 36ms のうち約 19ms（53%）が利用統計のディスク書き込みでした（1往復目 10.41ms ＋ 2往復目 9.58ms の中央値）。DEC-079 の内訳表は「9.8ms / 27%」としていますが、これは `CheckRunner.RunAll` の統計 ON/OFF 差分で、ウィンドウ側から呼ばれる2往復目が含まれていませんでした。

内容不変時の書き込みスキップ案は採用していません。カウンタが毎回増えるので**内容は必ず変わり**、実運用では一度も発火しないことが実測で分かったためです。遅延書き込み案は Issue #35 にコメントとして残しました。

### 3. 内訳行だけの Severity グループを描画しない（DEC-070 / T-9）

表示条件が生の `Count`、見出しの件数が `CountPrimary`（`IsDetail` を除いた数）とずれていたため、ある Severity の行がすべて内訳行だと見出しが `Error (0)` になります。表示条件を `ShouldDrawGroup`（`CountPrimary > 0`）に切り出して揃えました。

内訳行は「直前のサマリー行の内訳」という契約なので、サマリーのない内訳はユーザーにとって文脈のない断片です。件数表示を取り繕うより出さないほうが正しい、という判断です。ただし黙って検出が消えると気づけないので、`CheckRunner` 側で契約違反を `Debug.LogWarning` します。

現状 `IsDetail` を使うのは `DescriptorDuplicateCheck` だけで必ずサマリー行が先行するため到達不能ですが、**このPRの `UnsupportedComponentCheck` が2例目**になるため、今のうちに直しています。

## テスト

EditMode 130件が全緑です（既存109＋#36 の13＋T-8/T-9 の8）。検証環境は Unity 2022.3.22f1 / VRChat SDK 3.10.4 / `activeBuildTarget = StandaloneWindows64`。

`UnsupportedComponentCheckTests` では、件数の数え方・並び順・上位5型への集約をスキャン結果の注入で検証しています。SDK とアクティブビルドターゲットに依存させないためで、`QuestCompatibilityScannerTests` が `Scan(GameObject, bool)` を使っているのと同じ理由です。

ただし統合の2件（`実スキャナ経由でもMeshColliderを検出する` / `通常のアバター構成では実スキャナ経由でも何も出ない`）は、SDK の `FindIllegalComponents` が実際に MeshCollider を返すことに依存します。`#if UNITY_STANDALONE` 依存なので、**CI のビルドターゲットで同じ結果になるかはこのPRのCIで初めて確認します。**

T-8 の `UsageStatsSingleWriteTests` では、**チェック側とパフォーマンス側の検出を1回で渡しても `check_run_count` が1しか増えないこと**を固定しています。そもそも入口を2つに分けたのが二重計上を避けるためだったので、ここが崩れると統合した意味そのものが失われます。旧来の2入口を併用したときの保証が委譲後も維持されていることも、あわせて固定しました。

## 実描画確認

`TestAvatar` に一時オブジェクト（MeshCollider ×3 / AudioListener / Canvas / CanvasRenderer）を足して 498×437 のドッキング既定サイズで確認し、確認後に削除しました。

- パフォーマンスセクションから「アップロード時に取り除かれるもの（PC / Quest 共通）」が消えていること
- Foldout が `Warning (4)`（シェーダー3件＋サマリー1件）で、内訳4行が件数に入っていないこと
- サマリー行に「選択」ボタンが出ず、内訳行にだけ出ること
- MeshCollider が SDK 判定側、BoxCollider が Quest 側に正しく振り分けられていること（DEC-075 のデグレなし）

T-8 / T-9 は描画の見た目を変えないため（T-9 は到達不能な状態の表示条件、T-8 は書き込み経路のみ）、この確認はやり直していません。

## 明示的な保留

`CheckResult.TargetObject` は単数のため、内訳行では型ごとの代表1件しか Ping できません。`QuestIncompatibility` は `Targets`（複数）で一括選択できるので、そこだけ機能が落ちます。複数ターゲット対応は既存10チェック・カード書き出し・修正履歴に波及するため v0.10.0 のスコープには入れず、別 Issue として起票します。

Closes #36
Closes #35
