### PR TITLE
ci: Build Release に告知準備ゲートを追加（DEC-066）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,16 @@
 name: Build Release
 
-on: 
+on:
   workflow_dispatch:
+    inputs:
+      announcement_ready:
+        description: '告知素材が揃っているか（release-checklist.md の T-1 ゲート）。揃うまで no のままにする'
+        type: choice
+        required: true
+        default: 'no'
+        options:
+          - 'no'
+          - 'yes'
 
 jobs:
 
@@ -11,6 +20,26 @@ jobs:
     outputs:
       config_package: ${{ steps.config_package.outputs.configPackage }}
     steps:
+
+    # 告知準備ゲート（DEC-066）
+    # areas/operations/release-checklist.md の T-1「告知素材が揃っているか」を機械化したもの。
+    # 素材が揃わないまま公開だけ先行すると、告知が空振りする。
+    # v0.9.0 まではこの確認が手運用で、実際に一度素通りしている（DEC-074 ④）。
+    - name: Announcement Readiness Gate
+      env:
+        ANNOUNCEMENT_READY: ${{ inputs.announcement_ready }}
+      run: |
+        if [ "$ANNOUNCEMENT_READY" != "yes" ]; then
+          echo "::error::告知準備ゲート: announcement_ready が 'yes' ではないため、リリースを中止しました。"
+          echo "release-checklist.md T-1「告知素材が揃っているか」の3点を確認してください:"
+          echo "  1. X告知カード areas/brand/x-cards/vX.Y.Z-announce.png（2400x1350）"
+          echo "     ※ 実物のスクリーンショットがあっても必ず作る"
+          echo "  2. BOOTH カルーセル 枠6の差し替え画像（枠を増やすのではなく差し替える）"
+          echo "  3. BOOTH 商品説明の差分文面（見つける／教える／直す／残す のどのブロックに入れるか）"
+          echo "3点が揃ってから announcement_ready=yes で再実行してください。"
+          exit 1
+        fi
+        echo "告知準備ゲート: OK（announcement_ready=yes）"
 
     # Ensure that required repository variable has been created for the Package
     - name: Validate Package Config


### PR DESCRIPTION
## 概要

`release-checklist.md` の T-1「告知素材が揃っているか」を機械化した告知準備ゲートを Build Release ワークフローに追加します（DEC-066）。

## 変更内容

- `workflow_dispatch` に入力 `announcement_ready` を追加（`type: choice` / 選択肢 `no`・`yes` / 既定 `no` / required）
- **最初に走る `config` ジョブの冒頭**にガードステップを追加し、`yes` 以外なら `exit 1` で中止する。`build` ジョブは `needs: config` なので連鎖して止まる
- 失敗時のログに T-1 の告知素材3点を出力する:
  1. X告知カード（2400×1350）
  2. BOOTH カルーセル 枠6の差し替え画像
  3. BOOTH 商品説明の差分文面
- **既存の手動起動フロー（`workflow_dispatch` のみ・タグは Action 内で自動作成）は変えていない**
- 入力値は `${{ }}` を直接シェルへ展開せず、`env:` 経由で渡している
- 既存の SHA ピン留め行には一切触れていない（差分は +30/-1 行）

## 背景

v0.9.0 では告知素材の確認が手運用のまま素通りし、DEC-074 ④ で「ゲートの実装は次回リリース（v0.10.0）から適用する」と期限を切っていた。ロードマップ上の期限は 2026-08-20。

## 検証

- `actionlint 1.7.12` で warning 0
- PyYAML でのパース OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)