### PR TITLE
ci: create-unitypackage を SHA ピン留めに揃える (#48)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
       
       # Make a UnityPackage version of the Package for release
       - name: Create UnityPackage
-        uses: pCYSl5EDgo/create-unitypackage@v1.2.3
+        uses: pCYSl5EDgo/create-unitypackage@b5c57408698b1fab8b3a84d4b67f767b8b7c0be9 # v1.2.3
         with:
           package-path: ${{ env.unityPackage }}
           include-files: metaList


### PR DESCRIPTION
Closes #48

## 何を変えたか

`.github/workflows/release.yml` で唯一タグ参照のまま残っていた `pCYSl5EDgo/create-unitypackage` を、コミット SHA のピン留めに揃えました。**変更は1行だけです。**

```diff
-        uses: pCYSl5EDgo/create-unitypackage@v1.2.3
+        uses: pCYSl5EDgo/create-unitypackage@b5c57408698b1fab8b3a84d4b67f767b8b7c0be9 # v1.2.3
```

## なぜ

DEC-082 決定事項6 で「CI のアクションは書き方を `release.yml` の SHA ピン留めに揃える」と決めているのに、その基準を作った当のファイルにだけ例外が残っていました。タグは可変なので、上流で付け替えられると内容が黙って変わります。ここは Release 成果物（zip / unitypackage）を作るステップで、変わったことに気づく経路がありません。

## SHA の確認方法

GitHub のタグ一覧を直接引いて照合しました。

| タグ | SHA |
|---|---|
| `v1.2.3` | `b5c57408698b1fab8b3a84d4b67f767b8b7c0be9` |

**他3行の SHA には触れていません。** 2026-04-25 に `actions/checkout` と `softprops/action-gh-release` の SHA が入れ違いになって Build Release が落ちた事故があるため、既存行は1文字も動かしていません（diff が1行であることで確認できます）。

## 検証について

`release.yml` は `workflow_dispatch` のみで起動し、実行すると本物の Release とタグが作られるため、**マージ前に単体で試し撃ちできません。**実地検証は v0.10.0 の Build Release（8/25 予定）が初回になります。Issue #48 に書かれている通りの制約です。

## タイミング

v0.10.0 の公開より前に入れておくと、実地検証を1回ぶんにまとめられます。
