### PR TITLE
feat: MA ObjectToggle に「調べる」リンクを追加し、MA 系リンクを日本語版に向ける

### DIFF
--- a/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/MAObjectToggleCheck.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/Checks/MAObjectToggleCheck.cs
@@ -42,7 +42,8 @@ namespace AvatarOmamori.Editor.Checks
                             Severity.Warning,
                             $"[MA] ObjectToggle \"{toggle.gameObject.name}\" のトグルリスト [{i}] のターゲットが空です。このエントリは何も切り替えません。",
                             toggle,
-                            hint: "切り替えたいオブジェクトを指定するか、使わないエントリは削除できます。"
+                            hint: "切り替えたいオブジェクトを指定するか、使わないエントリは削除できます。",
+                            documentUrl: OmamoriDocUrls.MaObjectToggle
                         );
                     }
                     else if (targetGo == toggle.gameObject)
@@ -51,7 +52,8 @@ namespace AvatarOmamori.Editor.Checks
                             Severity.Error,
                             $"[MA] ObjectToggle \"{toggle.gameObject.name}\" のトグルリスト [{i}] が自身の GameObject を参照しています。MAビルドエラー（MA-1200）の原因になります。",
                             toggle,
-                            hint: "自分自身ではなく、切り替えたい別のオブジェクトを指定できます。"
+                            hint: "自分自身ではなく、切り替えたい別のオブジェクトを指定できます。",
+                            documentUrl: OmamoriDocUrls.MaObjectToggle
                         );
                     }
                 }

--- a/Packages/com.tsukumodo.avatar-omamori/Editor/OmamoriDocUrls.cs
+++ b/Packages/com.tsukumodo.avatar-omamori/Editor/OmamoriDocUrls.cs
@@ -37,16 +37,23 @@ namespace AvatarOmamori.Editor
         public const string AnimatorParameters = "https://creators.vrchat.com/avatars/animator-parameters/";
 
         /// <summary>Modular Avatar の Merge Armature の解説（衣装をアバターの Armature に統合する側）。</summary>
-        public const string MaMergeArmature = "https://modular-avatar.nadena.dev/docs/reference/merge-armature";
+        public const string MaMergeArmature = "https://modular-avatar.nadena.dev/ja/docs/reference/merge-armature";
 
         /// <summary>Expression Menu / Controls の解説。</summary>
         public const string ExpressionsMenu = "https://creators.vrchat.com/avatars/expression-menu-and-controls/";
 
         /// <summary>Modular Avatar の Bone Proxy の解説（特定ボーンへの追従）。</summary>
-        public const string MaBoneProxy = "https://modular-avatar.nadena.dev/docs/reference/bone-proxy";
+        public const string MaBoneProxy = "https://modular-avatar.nadena.dev/ja/docs/reference/bone-proxy";
 
         /// <summary>Modular Avatar の Menu Installer の解説（Menu Item をアバターのメニューに接続する側）。</summary>
-        public const string MaMenuInstaller = "https://modular-avatar.nadena.dev/docs/reference/menu-installer";
+        public const string MaMenuInstaller = "https://modular-avatar.nadena.dev/ja/docs/reference/menu-installer";
+
+        /// <summary>
+        /// Modular Avatar の Object Toggle の解説（他のオブジェクトの表示/非表示を切り替える側）。
+        /// 公式サイトの改編で <c>docs/reference/</c> 直下から <c>docs/reference/reaction/</c> へ移っているため、
+        /// 他の MA 系リンクとパスの形が違う。
+        /// </summary>
+        public const string MaObjectToggle = "https://modular-avatar.nadena.dev/ja/docs/reference/reaction/object-toggle";
 
         /// <summary>
         /// VRChat がアバターで許可しているコンポーネントの一覧。


### PR DESCRIPTION
## 経緯

v0.10.0 の動作確認（W2）で、修正ヒント基盤の `DocumentUrl` が **11 チェック中 5 つにしか付いていない**ことが分かりました。設計書 §6 の T-3 は「全チェックに `Hint` / `DocumentUrl` 付与」と書いていますが、`CheckHintCoverageTests` は `Hint` しか検証していないため、テストでは落ちません。

URL が無い 6 つを個別に調べた結果がこちらです。

| チェック | 該当する公式ページ | 判断 |
|---|---|---|
| `MAObjectToggleCheck` | [Object Toggle（MA 公式）](https://modular-avatar.nadena.dev/ja/docs/reference/reaction/object-toggle) | **付ける** |
| `AnimatorLayerWeightCheck` | [Playable Layers](https://creators.vrchat.com/avatars/playable-layers) はあるが **Weight そのものの記載が無い** | 付けない |
| `DescriptorDuplicateCheck` | 見つからず | 付けない |
| `EmissionCheck` | 見つからず（Unity 側の機能で、VRChat 公式に項目が無い） | 付けない |
| `MissingScriptCheck` | 見つからず（Unity 側の概念） | 付けない |
| `MissingShaderCheck` | 見つからず（本質は lilToon 等の導入案内） | 付けない |

**無理にリンクを当てると「開いても書いていない」状態になり、かえって迷わせます。**該当ページがある1つだけを足し、残り5つは意図的に付けません。この判断はコード上のコメントとしても残しています。

## 変更内容

1. **`OmamoriDocUrls.MaObjectToggle` を追加**し、`MAObjectToggleCheck` の2つの結果（ターゲット空 / 自己参照）に付与
2. **既存の MA 系リンク3本を日本語版（`/ja/`）に向ける** — `MaMergeArmature` / `MaBoneProxy` / `MaMenuInstaller`

2 について。おまもりは改変初心者を対象にしているので、英語版を開かせる必然性がありません。Modular Avatar の公式ドキュメントは URL に `/ja/` を挟むだけで日本語版になります。**4本とも実在とページ内容を確認済み**です（Object Toggle は公式サイトの改編で `docs/reference/` 直下から `docs/reference/reaction/` へ移っており、他と URL の形が違う点はコメントに書いています）。

VRChat 公式ドキュメント（`creators.vrchat.com`）側は日本語版が無いため、そのままです。

## 確認したこと

- **EditMode テスト 143 件すべて緑**（手元の Unity 2022.3.22f1 / Komano プロジェクトで実測）
- 追加した定数が実際に解決されることを Editor 上で確認
- 既存3本の日本語ページが実在し、本文が日本語であることを1本ずつ確認

## 確認していないこと

`MAObjectToggleCheck` は Modular Avatar のコンポーネントが実際に存在しないと発火しないため、**「調べる」ボタンが実画面に出るところまでは見ていません。**MA 系3チェックのテスト整備は Issue #23 に据え置いたままです。
